### PR TITLE
add codec revision 0x100103 (1048835) for ALC221

### DIFF
--- a/Resources/ALC221/Info.plist
+++ b/Resources/ALC221/Info.plist
@@ -14,7 +14,7 @@
 		<array>
 			<dict>
 				<key>Comment</key>
-				<string>Goldfish64 - ALC221 for HP Compaq Pro 4300/Pro 6300/Elite 8300</string>
+				<string>Goldfish64 - ALC221 for HP Compaq Pro 4300/Pro 6300/Elite 8300/EliteDesk 800 G2 TWR</string>
 				<key>Id</key>
 				<integer>11</integer>
 				<key>Path</key>
@@ -25,7 +25,7 @@
 		<array>
 			<dict>
 				<key>Comment</key>
-				<string>Goldfish64 - ALC221 for HP Compaq Pro 4300/Pro 6300/Elite 8300</string>
+				<string>Goldfish64 - ALC221 for HP Compaq Pro 4300/Pro 6300/Elite 8300/EliteDesk 800 G2 TWR</string>
 				<key>Id</key>
 				<integer>11</integer>
 				<key>Path</key>
@@ -151,6 +151,7 @@
 	<key>Revisions</key>
 	<array>
 		<integer>1048579</integer>
+		<integer>1048835</integer>
 	</array>
 	<key>Vendor</key>
 	<string>Realtek</string>


### PR DESCRIPTION
added support for my HP EliteDesk 800 G2 TWR. All I had to do is edit `Resources/ALC221/Info.plist` and add my codec revision `<integer>1048835</integer>` on the file. I compiled it and I have been using it happily for many weeks now.