### PR TITLE
Fix AppleHDA patch for ALC257

### DIFF
--- a/Resources/ALC257/Info.plist
+++ b/Resources/ALC257/Info.plist
@@ -127,7 +127,7 @@
 			<key>Count</key>
 			<integer>2</integer>
 			<key>Find</key>
-			<data>ixnUEQ==</data>
+			<data>hBnUEQ==</data>
 			<key>MinKernel</key>
 			<integer>13</integer>
 			<key>Name</key>


### PR DESCRIPTION
The original patch replaces `11D4198B` into the ALC257 codec `EC100257`. It does not work for ALC257 codec used by ThinkPad T480s and T480 ([source](https://www.hackintosh-forum.de/index.php/Thread/37614-Lenovo-T480/?postID=434080#post434080)). There will be no audio devices at all.

ALC257 is very similar to ALC256 and I checked the patch in ALC256 which replaces `11D41984` instead. I also used this patch for ALC257, which now works perfectly on my ThinkPad T480s.

This pull request changes the patch for ALC257 to replace `11D41984` instead of `11D4198B`.