### PR TITLE
Alc controller patch disable

### DIFF
--- a/AppleALC.xcodeproj/project.pbxproj
+++ b/AppleALC.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 				1C748C281C21952C0024EED2 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		1C748C281C21952C0024EED2 /* Products */ = {
 			isa = PBXGroup;
@@ -518,7 +519,7 @@
 				MODULE_NAME = as.vit9696.AppleALC;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.3.3;
+				MODULE_VERSION = 1.3.3d4;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -563,7 +564,7 @@
 				MODULE_NAME = as.vit9696.AppleALC;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.3.3;
+				MODULE_VERSION = 1.3.3d4;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",

--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -532,9 +532,10 @@ void AlcEnabler::updateResource(Resource type, kern_return_t &result, const void
 
 void AlcEnabler::grabControllers() {
 	computerModel = WIOKit::getComputerModel();
+	auto sectPCI = WIOKit::findEntryByPrefix("/AppleACPIPlatformExpert", "PCI", gIOServicePlane);
 
 	for (size_t lookup = 0; lookup < ADDPR(codecLookupSize); lookup++) {
-		auto sect = WIOKit::findEntryByPrefix("/AppleACPIPlatformExpert", "PCI", gIOServicePlane);
+		auto sect = sectPCI;
 		
 		for (size_t i = 0; sect && i <= ADDPR(codecLookup)[lookup].controllerNum; i++) {
 			sect = WIOKit::findEntryByPrefix(sect, ADDPR(codecLookup)[lookup].tree[i], gIOServicePlane);
@@ -565,6 +566,7 @@ void AlcEnabler::grabControllers() {
 				uint32_t nopatch = 0;
 				WIOKit::getOSDataValue(sect, "alc-controller-patch-disable", nopatch);
 				insertController(ven, dev, rev, platform, nopatch, lid, ADDPR(codecLookup)[lookup].detect, &ADDPR(codecLookup)[lookup]);
+				break;
 			}
 		}
 	}

--- a/AppleALC/kern_alc.hpp
+++ b/AppleALC/kern_alc.hpp
@@ -185,11 +185,11 @@ private:
 	 *  Controller identification and modification info
 	 */
 	class ControllerInfo {
-		ControllerInfo(uint32_t ven, uint32_t dev, uint32_t rev, uint32_t p, uint32_t lid, bool d) :
-		vendor(ven), device(dev), revision(rev), platform(p), layout(lid), detect(d) {}
+		ControllerInfo(uint32_t ven, uint32_t dev, uint32_t rev, uint32_t p, uint32_t lid, bool d, bool np) :
+		vendor(ven), device(dev), revision(rev), platform(p), layout(lid), detect(d), nopatch(np) {}
 	public:
-		static ControllerInfo *create(uint32_t ven, uint32_t dev, uint32_t rev, uint32_t p, uint32_t lid, bool d) {
-			return new ControllerInfo(ven, dev, rev, p, lid, d);
+		static ControllerInfo *create(uint32_t ven, uint32_t dev, uint32_t rev, uint32_t p, uint32_t lid, bool d, bool np) {
+			return new ControllerInfo(ven, dev, rev, p, lid, d, np);
 		}
 		static void deleter(ControllerInfo *info) { delete info; }
 		const ControllerModInfo *info {nullptr};
@@ -200,6 +200,7 @@ private:
 		uint32_t const platform {ControllerModInfo::PlatformAny};
 		uint32_t const layout;
 		bool const detect;
+		bool const nopatch;
 	};
 
 	/**
@@ -211,8 +212,8 @@ private:
 	/**
 	 *  Insert a controller with given parameters
 	 */
-	void insertController(uint32_t ven, uint32_t dev, uint32_t rev, uint32_t p=ControllerModInfo::PlatformAny, uint32_t lid=0, bool d=false, const CodecLookupInfo *lookup = nullptr) {
-		auto controller = ControllerInfo::create(ven, dev, rev, p, lid, d);
+	void insertController(uint32_t ven, uint32_t dev, uint32_t rev, bool np, uint32_t p=ControllerModInfo::PlatformAny, uint32_t lid=0, bool d=false, const CodecLookupInfo *lookup = nullptr) {
+		auto controller = ControllerInfo::create(ven, dev, rev, p, lid, d, np);
 		if (controller) {
 			if (controllers.push_back(controller)) {
 				controller->lookup = lookup;


### PR DESCRIPTION
This change allows disabling of AppleALC's patching for controllers.
We ran into a situation with unsupported HDAU 0x0a0c on the Lenovo Y50.
Details start here:
https://www.tonymacx86.com/threads/guide-lenovo-y50-uhd-or-1080p-using-clover-uefi.261723/page-2#post-1831046

Eventually, we determine that the patching for AppleHDAController to accommodate 0x0c0c (as 0x0a0c) the way AppleALC does it simply does not work as well as the FakePCIID_Intel_HDMI_Audio.kext technique.

By disabling that feature in AppleALC, we can use FakePCIID_Intel_HDMI_Audio.kext to do the 0x0c0c -> 0x0a0c mapping instead.

The way I decided to allow this is by detecting property 'alc-controller-patch-disable'=<01 00 00 00> (or any non-zero injected on HDAU). Having that property present will disable patching within AppleALC for that specific controller.  The way it is coded, it applies to any controller that might be supported/patched by AppleALC, not just HDAU.

I also did a bit of cleanup in AlcEnabler::grabControllers.

I also changed the tab settings for the project, such that tabs during editing are not dependent on Xcode system-wide preferences, but rather the project specifies it explicitly.

For the future, I might suggest that AppleALC spoof PCI IDs as is done in FakePCIID, but perhaps with the same technique used by WhateverGreen.  This would obviate the need for FakePCIID most of the time, as this example (0x0c0c->0x0a0c) would work properly.