### PR TITLE
Add no-alc-controller property for excluding specific HDMI audio controllers

### DIFF
--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -101,18 +101,18 @@ void AlcEnabler::updateProperties() {
 
 		// Fourthly, update all the GPU devices if any
 		for (size_t gpu = 0; gpu < devInfo->videoExternal.size(); gpu++) {
-			auto hdaSevice = devInfo->videoExternal[gpu].audio;
+			auto hdaService = devInfo->videoExternal[gpu].audio;
 			auto gpuService = devInfo->videoExternal[gpu].video;
 
-			if (!hdaSevice || !validateInjection(hdaSevice))
+			if (!hdaService || !validateInjection(hdaService))
 				continue;
 
 			uint32_t ven = devInfo->videoExternal[gpu].vendor;
 			uint32_t dev = 0, rev = 0;
-			if (WIOKit::getOSDataValue(hdaSevice, "device-id", dev) &&
-				WIOKit::getOSDataValue(hdaSevice, "revision-id", rev)) {
+			if (WIOKit::getOSDataValue(hdaService, "device-id", dev) &&
+				WIOKit::getOSDataValue(hdaService, "revision-id", rev)) {
 				// Register the controller
-				insertController(ven, dev, rev, nullptr != hdaSevice->getProperty("no-controller-patch"));
+				insertController(ven, dev, rev, nullptr != hdaService->getProperty("no-controller-patch"));
 				// Disable the id in the list if any
 				if (ven == WIOKit::VendorID::NVIDIA) {
 					uint32_t device = (dev << 16) | WIOKit::VendorID::NVIDIA;
@@ -125,7 +125,7 @@ void AlcEnabler::updateProperties() {
 			// Refresh the main properties including hda-gfx.
 			char hdaGfx[16];
 			snprintf(hdaGfx, sizeof(hdaGfx), "onboard-%u", hdaGfxCounter++);
-			updateDeviceProperties(hdaSevice, devInfo, hdaGfx, false);
+			updateDeviceProperties(hdaService, devInfo, hdaGfx, false);
 			gpuService->setProperty("hda-gfx", hdaGfx, static_cast<uint32_t>(strlen(hdaGfx)+1));
 
 			// Refresh connector types on NVIDIA, since they are required for HDMI audio to function.

--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -755,10 +755,13 @@ bool AlcEnabler::validateCodecs() {
 bool AlcEnabler::validateInjection(IORegistryEntry *hdaService) {
 	// Check for no-controller-inject. If set, ignore the controller.
 	uint32_t noControllerInject = 0;
-	auto name = hdaService->getName();
-	
 	WIOKit::getOSDataValue(hdaService, "no-controller-inject", noControllerInject);
-	DBGLOG("alc", "%sinjecting %s", noControllerInject ? "not " : "", name);
+	
+	if (noControllerInject) {
+		auto name = hdaService->getName();
+		SYSLOG("alc", "not injecting %s", name);
+	}
+	
 	return noControllerInject == 0;
 }
 

--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -106,6 +106,12 @@ void AlcEnabler::updateProperties() {
 
 			if (!hdaSevice)
 				continue;
+			
+			// If a no-alc-controller property is set, ignore.
+			uint32_t noAlcController = 0;
+			WIOKit::getOSDataValue(hdaSevice, "no-alc-controller", noAlcController);
+			if (noAlcController)
+				continue;
 
 			uint32_t ven = devInfo->videoExternal[gpu].vendor;
 			uint32_t dev = 0, rev = 0;

--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -754,15 +754,11 @@ bool AlcEnabler::validateCodecs() {
 
 bool AlcEnabler::validateInjection(IORegistryEntry *hdaService) {
 	// Check for no-controller-inject. If set, ignore the controller.
-	uint32_t noControllerInject = 0;
-	WIOKit::getOSDataValue(hdaService, "no-controller-inject", noControllerInject);
+	bool noControllerInject = nullptr != hdaService->getProperty("no-controller-inject");
+	if (noControllerInject)
+		SYSLOG("alc", "not injecting %s", safeString(hdaService->getName()));
 	
-	if (noControllerInject) {
-		auto name = hdaService->getName();
-		SYSLOG("alc", "not injecting %s", name);
-	}
-	
-	return noControllerInject == 0;
+	return !noControllerInject;
 }
 
 void AlcEnabler::applyPatches(KernelPatcher &patcher, size_t index, const KextPatch *patches, size_t patchNum) {
@@ -779,5 +775,3 @@ void AlcEnabler::applyPatches(KernelPatcher &patcher, size_t index, const KextPa
 		}
 	}
 }
-
-

--- a/AppleALC/kern_alc.hpp
+++ b/AppleALC/kern_alc.hpp
@@ -158,6 +158,14 @@ private:
 	 *  @return true if anything suitable found
 	 */
 	bool validateCodecs();
+	
+	/**
+	 *  Checks for a set no-controller-injection property.
+	 *  @param hdaService  audio device
+	 *
+	 *  @return true if the controller should be injected
+	 */
+	bool validateInjection(IORegistryEntry *hdaService);
 
 	/**
 	 *  Apply kext patches for loaded kext index

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ AppleALC Changelog
 - Added Wern Apfel's menubar patch for CX20590
 - Added ALC255 layout-id 21 for Asus X441UA-WX096D by Andres ZeroCross
 - Added ALC255 layout-id 21 for Asus VivoBook Pro 15 CX8150 by Andres ZeroCross
+- Added ability to disable controller injection with property `no-controller-inject`
 
 #### v1.3.3
 - Added ability to disable controller patching by injecting property 'no-controller-patch' (for use of FakePCIID_Intel_HDMI_Audio)


### PR DESCRIPTION
I've encountered some issues with HDMI audio on older NVIDIA cards (GT218), likely caused by some incompatibility with AppleHDA, resulting in kextd stalls and nonworking HDMI audio. Applying this property "no-alc-controller" to the HDAU device with any non-zero value would prevent AppleALC from applying HDAU fixes to that controller if needed.