### PR TITLE
ALC256 layout-id 13 : disable invalid nodes to reduce headphone noise

### DIFF
--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -1197,9 +1197,13 @@
 					<integer>283902550</integer>
 					<key>ConfigData</key>
 					<data>
-					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
-					FwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIX
-					HRACFx4rAhcfAgFHDAI=
+					ASccEAEnHQABJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwgAUcdAAFHHhcBRx+QAYcc8AGH
+					HQABhx4AAYcfQAGXHDABlx0QAZceiwGXHwIB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccUAIXHRACFx4rAhcfAgFH
+					DAI=
 					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>


### PR DESCRIPTION
Disable node 0x13, 0x18, 0x1a, 0x1b, ox1d and 0x1e to significantly reduce headphone noise
Tested on xps 13 9250