### PR TITLE
Update Revision for CX20751/2

### DIFF
--- a/Resources/CX20751_2/Info.plist
+++ b/Resources/CX20751_2/Info.plist
@@ -173,6 +173,7 @@
 	<key>Revisions</key>
 	<array>
 		<integer>1048832</integer>
+		<integer>1048577</integer>
 	</array>
 	<key>Vendor</key>
 	<string>Conexant</string>


### PR DESCRIPTION
Update Revision 0x100001 for CX20751/2 (Toshiba Kira 107)