### PR TITLE
Fix ALC1220 audio after sleep.

### DIFF
--- a/Resources/ALC1220/Info.plist
+++ b/Resources/ALC1220/Info.plist
@@ -167,6 +167,18 @@
 			<key>Count</key>
 			<integer>1</integer>
 			<key>Find</key>
+			<data>xgYASIu/aAE=</data>
+			<key>MinKernel</key>
+			<integer>18</integer>
+			<key>Name</key>
+			<string>AppleHDA</string>
+			<key>Replace</key>
+			<data>xgYBSIu/aAE=</data>
+		</dict>
+		<dict>
+			<key>Count</key>
+			<integer>1</integer>
+			<key>Find</key>
 			<data>QcYGAEmLvCQ=</data>
 			<key>MaxKernel</key>
 			<integer>13</integer>


### PR DESCRIPTION
This PR fixes an issue where audio wasn't available after sleep on ALC1220 on 10.14.4.