### PR TITLE
Added wake verb for ALC1220 for MSI P65 Creator / MSI GS65.

### DIFF
--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -7423,6 +7423,10 @@
 					<integer>1</integer>
 					<key>LayoutID</key>
 					<integer>34</integer>
+					<key>WakeConfigData</key>
+					<data>AUcMAg==</data>
+					<key>WakeVerbReinit</key>
+					<true/>
 				</dict>
 				<dict>
 					<key>CodecID</key>


### PR DESCRIPTION
Previously sound would not restore after sleep. Now, sound works fine even after sleep. Everything seems to be working fine and it also builds properly.

FYI this layout is also compatible with MSI GS65 (for anyone who looks for this layout).