### PR TITLE
ALC700: fix HP and SPDIF outputs

### DIFF
--- a/Resources/ALC700/Platforms11.xml
+++ b/Resources/ALC700/Platforms11.xml
@@ -24,25 +24,7 @@
 			<string>osy - NUC8i7HNK/NUC8i7HVK</string>
 			<key>PathMap</key>
 			<array>
-				<array> <!-- Inputs -->
-					<!--
-					<array>  Headphone Microphone (NOT WORKING)
-						<array>
-							<dict>
-								<key>NodeID</key>
-								<integer>10</integer>
-							</dict>
-							<dict>
-								<key>NodeID</key>
-								<integer>37</integer>
-							</dict>
-							<dict>
-								<key>NodeID</key>
-								<integer>24</integer>
-							</dict>
-						</array>
-					</array>
-					-->
+				<array> <!-- Internal Microphone -->
 					<array> <!-- Int Microphone 1 -->
 						<array>
 							<dict>
@@ -130,7 +112,7 @@
 						</array>
 					</array>
 				</array>
-				<array> <!-- Outputs -->
+				<array> <!-- Analog Output -->
 					<array> <!-- Rear Line Out -->
 						<array>
 							<dict>
@@ -172,7 +154,7 @@
 							</dict>
 						</array>
 					</array>
-					<array> <!-- Front Headphone Output (NOT WORKING!) -->
+					<array> <!-- Front Headphone Output -->
 						<array>
 							<dict>
 								<key>Amp</key>
@@ -209,16 +191,17 @@
 									<false/>
 								</dict>
 								<key>NodeID</key>
-								<integer>3</integer>
+								<integer>2</integer>
 							</dict>
 						</array>
 					</array>
-					<!--
-					<array>   Rear SPDIF Output (NOT WORKING) 
+				</array>
+				<array> <!-- Digital Output -->
+					<array> <!-- Rear SPDIF Output -->
 						<array>
 							<dict>
-		                        <key>DetectDelegate</key>
-								<integer>xx</integer>
+								<key>NoPinSense</key>
+								<true/>
 								<key>NodeID</key>
 								<integer>30</integer>
 							</dict>
@@ -228,7 +211,6 @@
 							</dict>
 						</array>
 					</array>
-					-->
 				</array>
 			</array>
 			<key>PathMapID</key>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -9107,6 +9107,24 @@
 					<key>LayoutID</key>
 					<integer>28</integer>
 				</dict>
+				<dict>
+					<key>AFGLowPowerState</key>
+					<data>AwAAAA==</data>
+					<key>Codec</key>
+					<string>osy86 - Realtek ALC700</string>
+					<key>CodecID</key>
+					<integer>283903744</integer>
+					<key>ConfigData</key>
+					<data>AZceYQGXByU=</data>
+					<key>FuncGroup</key>
+					<integer>1</integer>
+					<key>LayoutID</key>
+					<integer>11</integer>
+					<key>WakeConfigData</key>
+					<data>AZcHJQ==</data>
+					<key>WakeVerbReinit</key>
+					<true/>
+				</dict>
 			</array>
 			<key>IOClass</key>
 			<string>AppleHDAHardwareConfigDriver</string>


### PR DESCRIPTION
SPDIF fixed with a new engine stream. HP jack fixed with custom verb init.