### PR TITLE
Add a support for disabling digital audio via boot arg, -alc-disable-digital-audio

### DIFF
--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -59,7 +59,7 @@ void AlcEnabler::updateProperties() {
 
 		// Respect desire to disable digital audio. This may be particularly useful for configurations
 		// with broken digital audio, resulting in kernel panics. Ref: https://github.com/acidanthera/bugtracker/issues/513
-		if (hasBuiltinDigitalAudio && devInfo->audioBuiltinAnalog && checkKernelArgument("-alc-disable-digital-audio"))
+		if (hasBuiltinDigitalAudio && devInfo->audioBuiltinAnalog && (devInfo->audioBuiltinAnalog->getProperty("No-hda-gfx") || checkKernelArgument("-alcnohdau")))
 			hasBuiltinDigitalAudio = false;
 
 		// Firstly, update Haswell or Broadwell HDAU device for built-in digital audio.

--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -59,7 +59,7 @@ void AlcEnabler::updateProperties() {
 
 		// Respect desire to disable digital audio. This may be particularly useful for configurations
 		// with broken digital audio, resulting in kernel panics. Ref: https://github.com/acidanthera/bugtracker/issues/513
-		if (hasBuiltinDigitalAudio && devInfo->audioBuiltinAnalog && devInfo->audioBuiltinAnalog->getProperty("No-hda-gfx"))
+		if (hasBuiltinDigitalAudio && devInfo->audioBuiltinAnalog && checkKernelArgument("-alc-disable-digital-audio"))
 			hasBuiltinDigitalAudio = false;
 
 		// Firstly, update Haswell or Broadwell HDAU device for built-in digital audio.
@@ -89,7 +89,7 @@ void AlcEnabler::updateProperties() {
 		// Secondly, update HDEF device and make it support digital audio
 		if (devInfo->audioBuiltinAnalog && validateInjection(devInfo->audioBuiltinAnalog)) {
 			const char *hdaGfx = nullptr;
-			if (hasBuiltinDigitalAudio && !devInfo->audioBuiltinDigital)
+			if (!devInfo->audioBuiltinDigital || !hasBuiltinDigitalAudio)
 				hdaGfx = "onboard-1";
 			updateDeviceProperties(devInfo->audioBuiltinAnalog, devInfo, hdaGfx, true);
 		}


### PR DESCRIPTION
Hi. This is to disable the digital audio via the boot argument. Please consider this code changes.

As you already know, with the Haswell chipset, when the system has connectionless digital audio, the kernel panic might be observed when waking up from sleep.

Using the boot argument would make it easier for the user to use it. Also, I have fixed an issue that "onboard-1" might not be created when the digital audio is disabled.

Test is done on the Haswell chipset:
- Without the boot argument, the audio works, but Kernel crashes when waking up from sleep
- WIth the boot argument, the audio works, and no kernel panic is observed.

Thanks.
Taeyon