### PR TITLE
add support intel NUC7 HDMI audio device-id 719d

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -594,6 +594,41 @@
 	</dict>
 	<dict>
 		<key>Device</key>
+		<integer>40305</integer>
+		<key>Name</key>
+		<string>100 Series PCH HD Audio</string>
+		<key>Patches</key>
+		<array>
+			<dict>
+				<key>Count</key>
+				<integer>6</integer>
+				<key>Find</key>
+				<data>cKEAAA==</data>
+				<key>MinKernel</key>
+				<integer>16</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>cZ0AAA==</data>
+			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>hoBwoQ==</data>
+				<key>MinKernel</key>
+				<integer>16</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>hoBxnQ==</data>
+			</dict>
+		</array>
+		<key>Vendor</key>
+		<string>Intel</string>
+	</dict>
+	<dict>
+		<key>Device</key>
 		<integer>41329</integer>
 		<key>Name</key>
 		<string>200 Series Mobile PCH HD Audio</string>


### PR DESCRIPTION
Fix the loss of HDMI sound after the  first boot / rebooting the system (without this edit, you should have unplug /plug the HDMI cable for fix)