### PR TITLE
fix layout 13 CX8050 microphone after sleep

### DIFF
--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -7804,7 +7804,7 @@
 					<key>LayoutID</key>
 					<integer>13</integer>
 					<key>WakeConfigData</key>
-					<data>AXcMAgFnDAI=</data>
+					<data>AXcMAgFnDAIBlwckAacHJA==</data>
 					<key>WakeVerbReinit</key>
 					<true/>
 				</dict>


### PR DESCRIPTION
The pincomplex verb works for both speakers (intSpeaker, Headphones), but strangely not the Internal or LineIn microphone.
The pincomplex is already set in the pinconfig, however it doesn't persist after sleep. As a workaround, I've added the necessary verbs to WakeConfigData. If this is not correct, please let me know.