### PR TITLE
Enable analog to digital when using "no-hda-gfx"

### DIFF
--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -56,11 +56,14 @@ void AlcEnabler::updateProperties() {
 	if (devInfo) {
 		// Assume that IGPU with connections means built-in digital audio.
 		bool hasBuiltinDigitalAudio = !devInfo->reportedFramebufferIsConnectorLess && devInfo->videoBuiltin;
+		bool forceBuiltinDigitalAudio = false;
 
 		// Respect desire to disable digital audio. This may be particularly useful for configurations
 		// with broken digital audio, resulting in kernel panics. Ref: https://github.com/acidanthera/bugtracker/issues/513
-		if (hasBuiltinDigitalAudio && devInfo->audioBuiltinAnalog && devInfo->audioBuiltinAnalog->getProperty("No-hda-gfx"))
+		if (hasBuiltinDigitalAudio && devInfo->audioBuiltinAnalog && devInfo->audioBuiltinAnalog->getProperty("no-hda-gfx")) {
 			hasBuiltinDigitalAudio = false;
+			forceBuiltinDigitalAudio = true;
+		}
 
 		// Firstly, update Haswell or Broadwell HDAU device for built-in digital audio.
 		if (devInfo->audioBuiltinDigital && validateInjection(devInfo->audioBuiltinDigital)) {
@@ -89,7 +92,7 @@ void AlcEnabler::updateProperties() {
 		// Secondly, update HDEF device and make it support digital audio
 		if (devInfo->audioBuiltinAnalog && validateInjection(devInfo->audioBuiltinAnalog)) {
 			const char *hdaGfx = nullptr;
-			if (hasBuiltinDigitalAudio && !devInfo->audioBuiltinDigital)
+			if ((hasBuiltinDigitalAudio && !devInfo->audioBuiltinDigital) || forceBuiltinDigitalAudio)
 				hdaGfx = "onboard-1";
 			updateDeviceProperties(devInfo->audioBuiltinAnalog, devInfo, hdaGfx, true);
 		}

--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -60,7 +60,7 @@ void AlcEnabler::updateProperties() {
 
 		// Respect desire to disable digital audio. This may be particularly useful for configurations
 		// with broken digital audio, resulting in kernel panics. Ref: https://github.com/acidanthera/bugtracker/issues/513
-		if (hasBuiltinDigitalAudio && devInfo->audioBuiltinAnalog && devInfo->audioBuiltinAnalog->getProperty("no-hda-gfx")) {
+		if (hasBuiltinDigitalAudio && devInfo->audioBuiltinAnalog && devInfo->audioBuiltinAnalog->getProperty("No-hda-gfx")) {
 			hasBuiltinDigitalAudio = false;
 			forceBuiltinDigitalAudio = true;
 		}


### PR DESCRIPTION
In Haswell chipset, if "no-hda-gfx" is used to fix the kernel panic issue, all audio are disabled. This commit makes the audio work.  Audio through IGPU will still not work though. I've tested with Gigabyte Z97 motherboard, Intel i7-4790 CPU, ALC888 chipset, macOS 10.15.0, audio port on back panel & front panel with an analog headset, and Clover config.plist

### 		
            <key>Properties</key>
		<dict>
			<key>PciRoot(0x0)/Pci(0x1b,0x0)</key>
			<dict>
				<key>layout-id</key>
				<integer>1</integer>
				<key>no-hda-gfx</key>
				<string>1</string>
			</dict>
		</dict>

