### PR TITLE
ALC700: fixed speaker/headphone priority

### DIFF
--- a/Resources/ALC700/Platforms11.xml
+++ b/Resources/ALC700/Platforms11.xml
@@ -113,7 +113,7 @@
 					</array>
 				</array>
 				<array> <!-- Analog Output -->
-					<array> <!-- Rear Line Out -->
+					<array> <!-- Rear Speaker Out -->
 						<array>
 							<dict>
 								<key>Amp</key>

--- a/Resources/ALC700/layout11.xml
+++ b/Resources/ALC700/layout11.xml
@@ -15,7 +15,7 @@
 			<dict/>
 			<key>SPDIFOut</key>
 			<dict/>
-			<key>LineOut</key>
+			<key>IntSpeaker</key>
 			<dict/>
 			<key>Mic</key>
 			<dict>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -5498,7 +5498,7 @@
 					<key>CodecID</key>
 					<integer>283903744</integer>
 					<key>ConfigData</key>
-					<data>AZceYQGXByU=</data>
+					<data>AZceYQGXByUBtx4R</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>


### PR DESCRIPTION
Currently the back port (labeled line out, usually connected to speakers)
takes priority over the front port (labeled microphone). That means if
both ports are plugged in, the back port takes priority even though it
makes more sense to have the back port always plugged in to a speaker and
the front port connected to something temporary like headphones. In
practice either port can work, but cable management can get ugly.

This is due to the fact that OSX prioritizes Line Out > HP > Speakers.
The default pin config labels the back port as Line Out but that doesn't
seem to be correct as it has an active amp attached which makes more sense
as a speaker output (line out is supposed to not have any amps). Therefore
this patch re-labels node 0x1B to be a "Speaker" port instead.

OSX also has no concept of an external speaker output, so we have to label
it (in the path file) as an "internal speaker" and it will show up as an
"internal speaker" but there is no way around that.