### PR TITLE
Added support for Intel C620 series PCH Audio

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -664,6 +664,41 @@
 	</dict>
 	<dict>
 		<key>Device</key>
+		<integer>41456</integer>
+		<key>Name</key>
+		<string>C620 Series PCH HD Audio</string>
+		<key>Patches</key>
+		<array>
+			<dict>
+				<key>Count</key>
+				<integer>6</integer>
+				<key>Find</key>
+				<data>cKEAAA==</data>
+				<key>MinKernel</key>
+				<integer>16</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>8KEAAA==</data>
+			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>hoBwoQ==</data>
+				<key>MinKernel</key>
+				<integer>16</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>hoDwoQ==</data>
+			</dict>
+		</array>
+		<key>Vendor</key>
+		<string>Intel</string>
+	</dict>
+	<dict>
+		<key>Device</key>
 		<integer>41800</integer>
 		<key>Name</key>
 		<string>300 Series PCH HD Audio</string>

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -675,7 +675,7 @@
 				<key>Find</key>
 				<data>cKEAAA==</data>
 				<key>MinKernel</key>
-				<integer>16</integer>
+				<integer>19</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>
@@ -687,7 +687,7 @@
 				<key>Find</key>
 				<data>hoBwoQ==</data>
 				<key>MinKernel</key>
-				<integer>16</integer>
+				<integer>19</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>


### PR DESCRIPTION
Seems to work great and no surprises:  just inject a layout-id of 1 like other intel PCH controllers and AppleALC will figure out which codec to use automatically (so just like the other Intel PCHs).  

The patch is identical to the 200 series PCH patches, except that the device id is A1F0 vs the 200 series' A2F0.  Tested with a C621 motherboard (a Supermicro X11DAi-N) using a Realtek ALC888 (I believe those, as well as ALC887 and ALC1220/B codecs are typically what get paired with a C621 chipset).  