### PR TITLE
Support optional configurable delay before start of AppleHDAController

### DIFF
--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -302,6 +302,7 @@ bool AlcEnabler::AppleHDAController_start(IOService* service, IOService* provide
 	return FunctionCast(AppleHDAController_start, callbackAlc->orgAppleHDAController_start)(service, provider);
 }
 
+#ifdef DEBUG
 IOReturn AlcEnabler::IOHDACodecDevice_executeVerb(void *that, uint16_t a1, uint16_t a2, uint16_t a3, unsigned int *a4, bool a5)
 {
 	IOReturn result = FunctionCast(IOHDACodecDevice_executeVerb, callbackAlc->orgIOHDACodecDevice_executeVerb)(that, a1, a2, a3, a4, a5);
@@ -309,6 +310,7 @@ IOReturn AlcEnabler::IOHDACodecDevice_executeVerb(void *that, uint16_t a1, uint1
 		DBGLOG("alc", "IOHDACodecDevice::executeVerb with parameters a1 = %u, a2 = %u, a3 = %u failed with result = %x", a1, a2, a3, result);
 	return result;
 }
+#endif
 
 uint32_t AlcEnabler::getAudioLayout(IOService *hdaDriver) {
 	auto parent = hdaDriver->getParentEntry(gIOServicePlane);
@@ -606,11 +608,13 @@ void AlcEnabler::processKext(KernelPatcher &patcher, size_t index, mach_vm_addre
 			eraseRedundantLogs(patcher, kextIndex);
 	}
 	
+#ifdef DEBUG
 	if (ADDPR(debugEnabled) && !(progressState & ProcessingState::PatchHDAFamily) && kextIndex == KextIdIOHDAFamily) {
 		progressState |= ProcessingState::PatchHDAFamily;
 		KernelPatcher::RouteRequest request("__ZN16IOHDACodecDevice11executeVerbEtttPjb", IOHDACodecDevice_executeVerb, orgIOHDACodecDevice_executeVerb);
 		patcher.routeMultiple(index, &request, 1, address, size);
 	}
+#endif
 	
 	if (!(progressState & ProcessingState::PatchHDAController) && kextIndex == KextIdAppleHDAController) {
 		progressState |= ProcessingState::PatchHDAController;

--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -279,6 +279,37 @@ IOService *AlcEnabler::gfxProbe(IOService *ctrl, IOService *provider, SInt32 *sc
 	return FunctionCast(gfxProbe, callbackAlc->orgGfxProbe)(ctrl, provider, score);
 }
 
+bool AlcEnabler::AppleHDAController_start(IOService* service, IOService* provider)
+{
+	uint32_t delay = 0;
+	if (PE_parse_boot_argn("alcdelay", &delay, sizeof(delay))) {
+		DBGLOG("alc", "found alc-delay override %u", delay);
+		provider->setProperty("alc-delay", &delay, sizeof(delay));
+	} else {
+		if (WIOKit::getOSDataValue(provider, "alc-delay", delay))
+			DBGLOG("alc", "found normal alc-delay %u", delay);
+	}
+	
+	if (delay > 3000) {
+		SYSLOG("alc", "alc delay cannot exceed 3000 ms, ignore it");
+		delay = 0;
+	}
+		
+	if (delay != 0) {
+		DBGLOG("alc", "delay AppleHDAController::start for %d ms", delay);
+		IOSleep(delay);
+	}
+	return FunctionCast(AppleHDAController_start, callbackAlc->orgAppleHDAController_start)(service, provider);
+}
+
+IOReturn AlcEnabler::IOHDACodecDevice_executeVerb(void *that, uint16_t a1, uint16_t a2, uint16_t a3, unsigned int *a4, bool a5)
+{
+	IOReturn result = FunctionCast(IOHDACodecDevice_executeVerb, callbackAlc->orgIOHDACodecDevice_executeVerb)(that, a1, a2, a3, a4, a5);
+	if (result != KERN_SUCCESS)
+		DBGLOG("alc", "IOHDACodecDevice::executeVerb with parameters a1 = %u, a2 = %u, a3 = %u failed with result = %x", a1, a2, a3, result);
+	return result;
+}
+
 uint32_t AlcEnabler::getAudioLayout(IOService *hdaDriver) {
 	auto parent = hdaDriver->getParentEntry(gIOServicePlane);
 	uint32_t layout = 0;
@@ -573,6 +604,24 @@ void AlcEnabler::processKext(KernelPatcher &patcher, size_t index, mach_vm_addre
 		// patch AppleHDA to remove redundant logs
 		if (!ADDPR(debugEnabled))
 			eraseRedundantLogs(patcher, kextIndex);
+	}
+	
+	if (ADDPR(debugEnabled) && !(progressState & ProcessingState::PatchHDAFamily) && kextIndex == KextIdIOHDAFamily) {
+		progressState |= ProcessingState::PatchHDAFamily;
+		KernelPatcher::RouteRequest requests[] {
+			KernelPatcher::RouteRequest("__ZN16IOHDACodecDevice11executeVerbEtttPjb", IOHDACodecDevice_executeVerb, orgIOHDACodecDevice_executeVerb),
+		};
+
+		patcher.routeMultiple(index, requests, address, size);
+	}
+	
+	if (!(progressState & ProcessingState::PatchHDAController) && kextIndex == KextIdAppleHDAController) {
+		progressState |= ProcessingState::PatchHDAController;
+		KernelPatcher::RouteRequest requests[] {
+			KernelPatcher::RouteRequest("__ZN18AppleHDAController5startEP9IOService", AppleHDAController_start, orgAppleHDAController_start),
+		};
+
+		patcher.routeMultiple(index, requests, address, size);
 	}
 	
 	// Ignore all the errors for other processors

--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -608,20 +608,14 @@ void AlcEnabler::processKext(KernelPatcher &patcher, size_t index, mach_vm_addre
 	
 	if (ADDPR(debugEnabled) && !(progressState & ProcessingState::PatchHDAFamily) && kextIndex == KextIdIOHDAFamily) {
 		progressState |= ProcessingState::PatchHDAFamily;
-		KernelPatcher::RouteRequest requests[] {
-			KernelPatcher::RouteRequest("__ZN16IOHDACodecDevice11executeVerbEtttPjb", IOHDACodecDevice_executeVerb, orgIOHDACodecDevice_executeVerb),
-		};
-
-		patcher.routeMultiple(index, requests, address, size);
+		KernelPatcher::RouteRequest request("__ZN16IOHDACodecDevice11executeVerbEtttPjb", IOHDACodecDevice_executeVerb, orgIOHDACodecDevice_executeVerb);
+		patcher.routeMultiple(index, &request, 1, address, size);
 	}
 	
 	if (!(progressState & ProcessingState::PatchHDAController) && kextIndex == KextIdAppleHDAController) {
 		progressState |= ProcessingState::PatchHDAController;
-		KernelPatcher::RouteRequest requests[] {
-			KernelPatcher::RouteRequest("__ZN18AppleHDAController5startEP9IOService", AppleHDAController_start, orgAppleHDAController_start),
-		};
-
-		patcher.routeMultiple(index, requests, address, size);
+		KernelPatcher::RouteRequest request("__ZN18AppleHDAController5startEP9IOService", AppleHDAController_start, orgAppleHDAController_start);
+		patcher.routeMultiple(index, &request, 1, address, size);
 	}
 	
 	// Ignore all the errors for other processors

--- a/AppleALC/kern_alc.hpp
+++ b/AppleALC/kern_alc.hpp
@@ -67,13 +67,25 @@ private:
 	 *  Hooked AppleGFXHDA probe
 	 */
 	static IOService *gfxProbe(IOService *ctrl, IOService *provider, SInt32 *score);
-
+	
+	/**
+	 *  Hooked AppleHDAController start
+	 */
+	static bool AppleHDAController_start(IOService* service, IOService* provider);
+	
+	/**
+	 *  Hooked IOHDACodecDevice executeVerb
+	 */
+	static IOReturn IOHDACodecDevice_executeVerb(void *that, uint16_t a1, uint16_t a2, uint16_t a3, unsigned int *a4, bool a5);
+		
 	/**
 	 *  Trampolines for original method invocations
 	 */
 	mach_vm_address_t orgLayoutLoadCallback {0};
 	mach_vm_address_t orgPlatformLoadCallback {0};
 	mach_vm_address_t orgGfxProbe {0};
+	mach_vm_address_t orgAppleHDAController_start {0};
+	mach_vm_address_t orgIOHDACodecDevice_executeVerb {0};
 
 	/**
 	 *  @enum IOAudioDevicePowerState
@@ -271,7 +283,9 @@ private:
 			NotReady = 0,
 			ControllersLoaded = 1,
 			CodecsLoaded = 2,
-			CallbacksWantRouting = 4
+			CallbacksWantRouting = 4,
+			PatchHDAFamily = 8,
+			PatchHDAController = 16
 		};
 	};
 	int progressState {ProcessingState::NotReady};

--- a/AppleALC/kern_alc.hpp
+++ b/AppleALC/kern_alc.hpp
@@ -76,7 +76,9 @@ private:
 	/**
 	 *  Hooked IOHDACodecDevice executeVerb
 	 */
+#ifdef DEBUG
 	static IOReturn IOHDACodecDevice_executeVerb(void *that, uint16_t a1, uint16_t a2, uint16_t a3, unsigned int *a4, bool a5);
+#endif
 		
 	/**
 	 *  Trampolines for original method invocations
@@ -85,7 +87,9 @@ private:
 	mach_vm_address_t orgPlatformLoadCallback {0};
 	mach_vm_address_t orgGfxProbe {0};
 	mach_vm_address_t orgAppleHDAController_start {0};
+#ifdef DEBUG
 	mach_vm_address_t orgIOHDACodecDevice_executeVerb {0};
+#endif
 
 	/**
 	 *  @enum IOAudioDevicePowerState

--- a/AppleALC/kern_resources.hpp
+++ b/AppleALC/kern_resources.hpp
@@ -88,6 +88,8 @@ extern const size_t ADDPR(vendorModSize);
 extern const size_t KextIdAppleHDAController;
 extern const size_t KextIdAppleHDA;
 extern const size_t KextIdAppleGFXHDA;
+#ifdef DEBUG
 extern const size_t KextIdIOHDAFamily;
+#endif
 
 #endif /* kern_resource_hpp */

--- a/AppleALC/kern_resources.hpp
+++ b/AppleALC/kern_resources.hpp
@@ -88,5 +88,6 @@ extern const size_t ADDPR(vendorModSize);
 extern const size_t KextIdAppleHDAController;
 extern const size_t KextIdAppleHDA;
 extern const size_t KextIdAppleGFXHDA;
+extern const size_t KextIdIOHDAFamily;
 
 #endif /* kern_resource_hpp */

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ AppleALC Changelog
 ==================
 #### v1.4.8
 - MaxKernel HS for GM/GP
+- Support optional configurable delay before start of AppleHDAController::start 
 
 #### v1.4.7
 - Added support for Intel C620 series PCH Audio

--- a/Resources/Kexts.plist
+++ b/Resources/Kexts.plist
@@ -33,5 +33,14 @@
 			<string>/System/Library/Extensions/AppleHDA.kext/Contents/PlugIns/AppleHDAController.kext/Contents/MacOS/AppleHDAController</string>
 		</array>
 	</dict>
+	<key>IOHDAFamily</key>
+	<dict>
+		<key>Id</key>
+		<string>com.apple.iokit.IOHDAFamily</string>
+		<key>Paths</key>
+		<array>
+			<string>/System/Library/Extensions/AppleHDA.kext/Contents/PlugIns/IOHDAFamily.kext/Contents/MacOS/IOHDAFamily</string>
+		</array>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This is a simple workaround for bug #422 - AppleALC working intermittently.
I tried different places where to put this delay, and AppleHDAController::start seems to be the best one.