### PR TITLE
Add patches for Mobile controller Cannon Lake PCH cAVS (8086:a348) revision 0x10

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ AppleALC Changelog
 #### v1.4.8
 - MaxKernel HS for GM/GP
 - Support startup delay for AppleHDAController via `alc-delay` property or `alcdelay` boot-arg (in ms)
+- Add patches for Mobile ALC295 (8086:a348) revision 0x10 (300 Series PCH HD Audio) to get HDMI Audio working (works after sleep/wake trick)
 
 #### v1.4.7
 - Added support for Intel C620 series PCH Audio

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@ AppleALC Changelog
 #### v1.4.8
 - MaxKernel HS for GM/GP
 - Support startup delay for AppleHDAController via `alc-delay` property or `alcdelay` boot-arg (in ms)
-- Add patches for Mobile ALC295 (8086:a348) revision 0x10 (300 Series PCH HD Audio) to get HDMI Audio working (works after sleep/wake trick)
+- Add patches for Mobile controller Cannon Lake PCH cAVS (8086:a348) revision 0x10 to get HDMI Audio working (works after sleep/wake trick)
 
 #### v1.4.7
 - Added support for Intel C620 series PCH Audio

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -698,6 +698,53 @@
 		<string>Intel</string>
 	</dict>
 	<dict>
+		<key>ComputerModel</key>
+		<integer>1</integer>
+		<key>Device</key>
+		<integer>41800</integer>
+		<key>Name</key>
+		<string>Mobile 300 Series PCH HD Audio, Revision 16 (0x10), fully works after sleep/wake trick</string>
+		<key>Patches</key>
+		<array>
+			<dict>
+				<key>Count</key>
+				<integer>6</integer>
+				<key>Find</key>
+				<data>cJ0AAA==</data>
+				<key>MaxKernel</key>
+				<integer>20</integer>
+				<key>MinKernel</key>
+				<integer>18</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>SKMAAA==</data>
+			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>hoBwnQ==</data>
+				<key>MaxKernel</key>
+				<integer>20</integer>
+				<key>MinKernel</key>
+				<integer>18</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>hoBIow==</data>
+			</dict>
+		</array>
+		<key>RevisionNum</key>
+		<integer>1</integer>
+		<key>Revisions</key>
+		<array>
+			<integer>16</integer>
+		</array>
+		<key>Vendor</key>
+		<string>Intel</string>
+	</dict>
+	<dict>
 		<key>Device</key>
 		<integer>41800</integer>
 		<key>Name</key>

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -698,12 +698,12 @@
 		<string>Intel</string>
 	</dict>
 	<dict>
-		<key>ComputerModel</key>
-		<integer>1</integer>
 		<key>Device</key>
-		<integer>41800</integer>
+		<real>41800</real>
+		<key>Model</key>
+		<string>Laptop</string>
 		<key>Name</key>
-		<string>Mobile 300 Series PCH HD Audio, Revision 16 (0x10), fully works after sleep/wake trick</string>
+		<string>Mobile Controller Cannon Lake PCH cAVS, Revision 16 (0x10), fully works after sleep/wake trick</string>
 		<key>Patches</key>
 		<array>
 			<dict>
@@ -711,8 +711,6 @@
 				<integer>6</integer>
 				<key>Find</key>
 				<data>cJ0AAA==</data>
-				<key>MaxKernel</key>
-				<integer>20</integer>
 				<key>MinKernel</key>
 				<integer>18</integer>
 				<key>Name</key>
@@ -725,8 +723,6 @@
 				<integer>1</integer>
 				<key>Find</key>
 				<data>hoBwnQ==</data>
-				<key>MaxKernel</key>
-				<integer>20</integer>
 				<key>MinKernel</key>
 				<integer>18</integer>
 				<key>Name</key>


### PR DESCRIPTION
Cannon Lake PCH cAVS is supported natively since Mojave.
But in my case HDMI Audio does not work.
I added patches for Mobile Cannon Lake PCH cAVS (8086:a348) revision 0x10 (300 Series PCH HD Audio) to get HDMI Audio working (works after sleep/wake trick).
I tried to minimise a possible influence to other users of controller Cannon Lake PCH cAVS, and wanted also to check platform, but the platform value was 0:
validating 0 controller 8086:3E9B:0, platform: 1050345472
validating 1 controller 8086:A348:10, platform: 0
