### PR TITLE
Fix Conexant CX20751/2 LineIn & Realtek ALC221 LineIn(s)

### DIFF
--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -36,12 +36,7 @@
 					<key>Comment</key>
 					<string>frankiezdh - Conexant CX20632 for HP ProDesk 480 G4</string>
 					<key>ConfigData</key>
-					<data>
-					AZccUAGXHRABlx4hAZcfAQGnHBABpx0QAace
-					oQGnHwEBxxyAAccdQQHHHgEBxx8BAdccIAHX
-					HTEB1x6BAdcfAQHXDAIB9xxAAfcdAQH3Hh8B
-					9x+R
-					</data>
+					<data>AZccUAGXHRABlx4hAZcfAQGnHBABpx0QAaceoQGnHwEBxxyAAccdQQHHHgEBxx8BAdccIAHXHTEB1x6BAdcfAQHXDAIB9xxAAfcdAQH3Hh8B9x+R</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -59,15 +54,7 @@
 					<key>Comment</key>
 					<string>CX20632 by Daniel</string>
 					<key>ConfigData</key>
-					<data>
-					AfccEAH3HQEB9x4XAfcfkgH3DAIBpxwgAacd
-					EAGnHosBpx8CAZccQAGXHRABlx4rAZcfAgHH
-					HNABxx1AAcceIQHHHwIBhxzwAYcdAAGHHgAB
-					hx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0A
-					AdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAgcc
-					8AIHHQACBx4AAgcfQAIXHPACFx0AAhceAAIX
-					H0ACZxzwAmcdAAJnHgACZx9A
-					</data>
+					<data>AfccEAH3HQEB9x4XAfcfkgH3DAIBpxwgAacdEAGnHosBpx8CAZccQAGXHRABlx4rAZcfAgHHHNABxx1AAcceIQHHHwIBhxzwAYcdAAGHHgABhx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAgcc8AIHHQACBx4AAgcfQAIXHPACFx0AAhceAAIXH0ACZxzwAmcdAAJnHgACZx9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -85,11 +72,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					ABcWHwAXFx4BVwoBAVcXDQFXGCQAtwwAANcc
-					8ADXHQAA1x4AANcfQAEXBwQBJx+QATceAAE3
-					H0ABhx4AAYcfQA==
-					</data>
+					<data>ABcWHwAXFx4BVwoBAVcXDQFXGCQAtwwAANcc8ADXHQAA1x4AANcfQAEXBwQBJx+QATceAAE3H0ABhx4AAYcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -103,11 +86,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					AVcKAQFnAwAAtxwQALcdQQC3HhAAtx+QANcc
-					8ADXHQAA1x4AANcfQAD3HCABFxxAARcegQEn
-					HDABJx+Q
-					</data>
+					<data>AVcKAQFnAwAAtxwQALcdQQC3HhAAtx+QANcc8ADXHQAA1x4AANcfQAD3HCABFxxAARcegQEnHDABJx+Q</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -121,11 +100,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					ABcXHgAXFRABVwoBAScIgQFnCIABVxcNAVcY
-					JADXHPAA1x0AANceAADXH0ABBx4hAScfkAE3
-					HPABNx0AATceAAE3H0A=
-					</data>
+					<data>ABcXHgAXFRABVwoBAScIgQFnCIABVxcNAVcYJADXHPAA1x0AANceAADXH0ABBx4hAScfkAE3HPABNx0AATceAAE3H0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -139,11 +114,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					ABcXHgAXFRQBVwoBAScIgQFnCIABVxcNAVcY
-					JADXHPAA1x0AANceAADXH0AA5xzwAOcdAADn
-					HgAA5x9AAQceAQEnH5A=
-					</data>
+					<data>ABcXHgAXFRQBVwoBAScIgQFnCIABVxcNAVcYJADXHPAA1x0AANceAADXH0AA5xzwAOcdAADnHgAA5x9AAQceAQEnH5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -157,12 +128,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					ABcWHwAXFx4AFxUUAVcKAQEnCIEBZwiAAVcX
-					DQFXGCQA1xzwANcdAADXHgAA1x9AAOcc8ADn
-					HQAA5x4AAOcfQAEHHgEBJx+QATcc8AE3HQAB
-					Nx4AATcfQAGHHPABhx0AAYceAAGHH0A=
-					</data>
+					<data>ABcWHwAXFx4AFxUUAVcKAQEnCIEBZwiAAVcXDQFXGCQA1xzwANcdAADXHgAA1x9AAOcc8ADnHQAA5x4AAOcfQAEHHgEBJx+QATcc8AE3HQABNx4AATcfQAGHHPABhx0AAYceAAGHH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -176,11 +142,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					ABcXHgAXFRIBVwoBAScIgQFnCIABVxcNAVcY
-					IQC3HiEA1xzwANcdAADXHgAA1x9AAQceAQEX
-					BwQBJx+Q
-					</data>
+					<data>ABcXHgAXFRIBVwoBAScIgQFnCIABVxcNAVcYIQC3HiEA1xzwANcdAADXHgAA1x9AAQceAQEXBwQBJx+Q</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -194,10 +156,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					ABcXHgAXFRABVwoBAScIgQFnCIABVxcNAVcY
-					JADXHPAA1x0AANceAADXH0ABBx4hAScfkA==
-					</data>
+					<data>ABcXHgAXFRABVwoBAScIgQFnCIABVxcNAVcYJADXHPAA1x0AANceAADXH0ABBx4hAScfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -211,13 +170,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					IVcKAQC3HBAAtx1AALceAQC3HwEAxxwgAMcd
-					gADHHkUAxx8BANccIADXHUAA1x4BANcfAQD3
-					HDAA9x1AAPceIQD3HwEBBxxAAQcdQAEHHiEB
-					Bx8CARccUAEXHUABFx4BARcfAQEnHFABJx2Q
-					AScepwEnH5A=
-					</data>
+					<data>IVcKAQC3HBAAtx1AALceAQC3HwEAxxwgAMcdgADHHkUAxx8BANccIADXHUAA1x4BANcfAQD3HDAA9x1AAPceIQD3HwEBBxxAAQcdQAEHHiEBBx8CARccUAEXHUABFx4BARcfAQEnHFABJx2QAScepwEnH5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -231,10 +184,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					AVcKAQAXFRQBJwiBAWcIgAFXFw0BVxgkIQce
-					AQEnH5A=
-					</data>
+					<data>AVcKAQAXFRQBJwiBAWcIgAFXFw0BVxgkIQceAQEnH5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -248,15 +198,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					IVcD8CFXFw0hVxgkIVcPgCC3HCAgtx1AILce
-					ASC3HwEgxxxgIMcdICDHHkUgxx8BINcc8CDX
-					HQAg1x4AINcfQCDnHPAg5x0AIOceACDnH0Ag
-					9xwvIPcdQCD3HiEg9x8BIQccMCEHHUAhBx4h
-					IQcfASEXHEAhFx0QIRceASEXHwEhJxwQIScd
-					kSEnHqEhJx+QITcc8CE3HQAhNx4AITcfQCGH
-					HFAhhx1gIYceASGHHwE=
-					</data>
+					<data>IVcD8CFXFw0hVxgkIVcPgCC3HCAgtx1AILceASC3HwEgxxxgIMcdICDHHkUgxx8BINcc8CDXHQAg1x4AINcfQCDnHPAg5x0AIOceACDnH0Ag9xwvIPcdQCD3HiEg9x8BIQccMCEHHUAhBx4hIQcfASEXHEAhFx0QIRceASEXHwEhJxwQIScdkSEnHqEhJx+QITcc8CE3HQAhNx4AITcfQCGHHFAhhx1gIYceASGHHwE=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -270,10 +212,7 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>
-					AVcKAQAXFx8AFxUQAScIgQFnCIABVxcNAVcY
-					JAEnH5A=
-					</data>
+					<data>AVcKAQAXFx8AFxUQAScIgQFnCIABVxcNAVcYJAEnH5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -287,11 +226,7 @@
 					<key>CodecID</key>
 					<integer>269697552</integer>
 					<key>ConfigData</key>
-					<data>
-					AFccEABXHUAAVx4hAFcfAABnHCAAZx0AAGce
-					FwBnH5AAdxwwAHcdkAB3HoEAdx8AAJccQACX
-					HQAAlx6gAJcfkA==
-					</data>
+					<data>AFccEABXHUAAVx4hAFcfAABnHCAAZx0AAGceFwBnH5AAdxwwAHcdkAB3HoEAdx8AAJccQACXHQAAlx6gAJcfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -305,11 +240,7 @@
 					<key>CodecID</key>
 					<integer>269697555</integer>
 					<key>ConfigData</key>
-					<data>
-					AEccEABHHRAARx4hAEcfAABXHCAAVx0AAFce
-					FwBXH5AAZxwwAGcdEABnHoEAZx8AAHccQAB3
-					HQAAdx6gAHcfkABXDAI=
-					</data>
+					<data>AEccEABHHRAARx4hAEcfAABXHCAAVx0AAFceFwBXH5AAZxwwAGcdEABnHoEAZx8AAHccQAB3HQAAdx6gAHcfkABXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -323,12 +254,7 @@
 					<key>CodecID</key>
 					<integer>299112836</integer>
 					<key>ConfigData</key>
-					<data>
-					ARccEAEXHUABFx4hARcfAAFHHCABRx1QAUce
-					gQFHHwABJxwwAScdAAEnHhcBJx+QAScMAgFX
-					HEABVx0AAVcepwFXH5ABxxyAAccdUAHHHoEB
-					xx8BAbccoAG3HRABtx5EAbcfIQ==
-					</data>
+					<data>ARccEAEXHUABFx4hARcfAAFHHCABRx1QAUcegQFHHwABJxwwAScdAAEnHhcBJx+QAScMAgFXHEABVx0AAVcepwFXH5ABxxyAAccdUAHHHoEBxx8BAbccoAG3HRABtx5EAbcfIQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -342,11 +268,7 @@
 					<key>CodecID</key>
 					<integer>299112778</integer>
 					<key>ConfigData</key>
-					<data>
-					ISccECEnHUAhJx4BIScfASFHHCAhRx2QIUce
-					oSFHHwIhVxwwIVcdMCFXHoEhVx8BIRccQCEX
-					HUAhFx4hIRcfAg==
-					</data>
+					<data>ISccECEnHUAhJx4BIScfASFHHCAhRx2QIUceoSFHHwIhVxwwIVcdMCFXHoEhVx8BIRccQCEXHUAhFx4hIRcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -360,11 +282,7 @@
 					<key>CodecID</key>
 					<integer>299112778</integer>
 					<key>ConfigData</key>
-					<data>
-					ISccECEnHUAhJx4RIScfkCFHHCAhRx2QIUce
-					oSFHHwIhVxwwIVcdMCFXHoEhVx8BIRccQCEX
-					HUAhFx4hIRcfAg==
-					</data>
+					<data>ISccECEnHUAhJx4RIScfkCFHHCAhRx2QIUceoSFHHwIhVxwwIVcdMCFXHoEhVx8BIRccQCEXHUAhFx4hIRcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -378,13 +296,7 @@
 					<key>CodecID</key>
 					<integer>299112778</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccAAEnHUABJx4BAScfAQHHHBABxx0wAcce
-					gQHHHwEBdxwgAXcdEAF3HqYBdx+5ARccMAEX
-					HUABFx4hARcfAQFnHEABZx1AAWceFwFnH5EB
-					pxxQAacdEAGnHvcBpx9RAbccYAG3HWABtx5E
-					AbcfAQE3HPABNx0QATceHwE3H1E=
-					</data>
+					<data>ASccAAEnHUABJx4BAScfAQHHHBABxx0wAccegQHHHwEBdxwgAXcdEAF3HqYBdx+5ARccMAEXHUABFx4hARcfAQFnHEABZx1AAWceFwFnH5EBpxxQAacdEAGnHvcBpx9RAbccYAG3HWABtx5EAbcfAQE3HPABNx0QATceHwE3H1E=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -398,16 +310,7 @@
 					<key>CodecID</key>
 					<integer>299112840</integer>
 					<key>ConfigData</key>
-					<data>
-					ARccQAEXHUABFx4hARcfAQEnHAABJx1AASce
-					EQEnHwEBNxzwATcdAAE3HgABNx9AAUccYAFH
-					HZABRx6gAUcfkAFXHIABVx0wAVcegQFXHwEB
-					ZxwgAWcdEAFnHgEBZx8BAXccUAF3HZABdx6B
-					AXcfAQGHHPABhx0AAYceAAGHH0ABtxygAbcd
-					8QG3HkUBtx8BAccc8AHHHQABxx4AAccfQAJH
-					HBACRx1gAkceAQJHHwECVxwwAlcdIAJXHgEC
-					Vx8B
-					</data>
+					<data>ARccQAEXHUABFx4hARcfAQEnHAABJx1AASceEQEnHwEBNxzwATcdAAE3HgABNx9AAUccYAFHHZABRx6gAUcfkAFXHIABVx0wAVcegQFXHwEBZxwgAWcdEAFnHgEBZx8BAXccUAF3HZABdx6BAXcfAQGHHPABhx0AAYceAAGHH0ABtxygAbcd8QG3HkUBtx8BAccc8AHHHQABxx4AAccfQAJHHBACRx1gAkceAQJHHwECVxwwAlcdIAJXHgECVx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -421,12 +324,7 @@
 					<key>CodecID</key>
 					<integer>299112843</integer>
 					<key>ConfigData</key>
-					<data>
-					ARccEAEXHUABFx4hARcfAQEnHCABJx1AASce
-					AQEnHwEBRxxAAUcdkAFHHqEBRx8BAVccUAFX
-					HTABVx6BAVcfAQF3HHABdx2QAXceoQF3HwEB
-					txzwAbcd8QG3HkUBtx8B
-					</data>
+					<data>ARccEAEXHUABFx4hARcfAQEnHCABJx1AASceAQEnHwEBRxxAAUcdkAFHHqEBRx8BAVccUAFXHTABVx6BAVcfAQF3HHABdx2QAXceoQF3HwEBtxzwAbcd8QG3HkUBtx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -440,14 +338,7 @@
 					<key>CodecID</key>
 					<integer>299112843</integer>
 					<key>ConfigData</key>
-					<data>
-					ARccEAEXHUABFx4hARcfAQEnHCABJx1AASce
-					EQEnHwEBRxwwAUcdkAFHHqABRx+QAWccQAFn
-					HRABZx4BAWcfAQF3HFABdx2QAXcegQF3HwEB
-					txxgAbcd8QG3HkUBtx8BAccccAHHHfEBxx7F
-					AccfAQHXHIAB1x3xAdceVgHXHxgCRxyQAkcd
-					YAJHHgECRx8BAlcckAJXHSACVx4BAlcfAQ==
-					</data>
+					<data>ARccEAEXHUABFx4hARcfAQEnHCABJx1AASceEQEnHwEBRxwwAUcdkAFHHqABRx+QAWccQAFnHRABZx4BAWcfAQF3HFABdx2QAXcegQF3HwEBtxxgAbcd8QG3HkUBtx8BAccccAHHHfEBxx7FAccfAQHXHIAB1x3xAdceVgHXHxgCRxyQAkcdYAJHHgECRx8BAlcckAJXHSACVx4BAlcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -463,14 +354,7 @@
 					<key>Comment</key>
 					<string>Custom AD1988B by Rodion</string>
 					<key>ConfigData</key>
-					<data>
-					AXccIAF3HZABdx6gAXcfkQFHHCEBRx2QAUce
-					gQFHHwIBJxwQAScdQAEnHhEBJx8BAkccEQJH
-					HWACRx4RAkcfAQFnHBIBZx0QAWceEQFnHwEC
-					VxwUAlcdIAJXHhECVx8BAccc8AHHHQABxx4A
-					AccfQAE3HPABNx0AATceAAE3H0ABpxzwAacd
-					AAGnHgABpx9AAYcc8AGHHQABhx4AAYcfQA==
-					</data>
+					<data>AXccIAF3HZABdx6gAXcfkQFHHCEBRx2QAUcegQFHHwIBJxwQAScdQAEnHhEBJx8BAkccEQJHHWACRx4RAkcfAQFnHBIBZx0QAWceEQFnHwECVxwUAlcdIAJXHhECVx8BAccc8AHHHQABxx4AAccfQAE3HPABNx0AATceAAE3H0ABpxzwAacdAAGnHgABpx9AAYcc8AGHHQABhx4AAYcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -484,12 +368,7 @@
 					<key>CodecID</key>
 					<integer>299145371</integer>
 					<key>ConfigData</key>
-					<data>
-					ARccEAEXHUABFx4hARcfAQEnHCABJx1AASce
-					AQEnHwEBRxxAAUcdkAFHHqEBRx8BAVccUAFX
-					HTABVx6BAVcfAQF3HHABdx2QAXceoQF3HwEB
-					txzwAbcd8QG3HkUBtx8B
-					</data>
+					<data>ARccEAEXHUABFx4hARcfAQEnHCABJx1AASceAQEnHwEBRxxAAUcdkAFHHqEBRx8BAVccUAFXHTABVx6BAVcfAQF3HHABdx2QAXceoQF3HwEBtxzwAbcd8QG3HkUBtx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -503,14 +382,7 @@
 					<key>CodecID</key>
 					<integer>299145371</integer>
 					<key>ConfigData</key>
-					<data>
-					ARccMAEXHUABFx4hARcfAQEnHBABJx1AASce
-					EQEnHwEBRxxAAUcdkAFHHqABRx+QAWccUAFn
-					HRABZx4BAWcfAQF3HCABdx2QAXcegQF3HwEB
-					txygAbcd8QG3HkUBtx8BAcccYAHHHfEBxx7F
-					AccfAQHXHLAB1x3xAdceVgHXHxgCRxxwAkcd
-					YAJHHgECRx8BAlccgAJXHSACVx4BAlcfAQ==
-					</data>
+					<data>ARccMAEXHUABFx4hARcfAQEnHBABJx1AASceEQEnHwEBRxxAAUcdkAFHHqABRx+QAWccUAFnHRABZx4BAWcfAQF3HCABdx2QAXcegQF3HwEBtxygAbcd8QG3HkUBtx8BAcccYAHHHfEBxx7FAccfAQHXHLAB1x3xAdceVgHXHxgCRxxwAkcdYAJHHgECRx8BAlccgAJXHSACVx4BAlcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -524,11 +396,7 @@
 					<key>CodecID</key>
 					<integer>283902485</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQEBRx4XAUcfmQIXHCACFx0QAhce
-					IQIXHwECFwwCASccMAEnHRgBJx6BAScfAQGX
-					HEABlx0BAZcepgGXH5kBRwwC
-					</data>
+					<data>AUccEAFHHQEBRx4XAUcfmQIXHCACFx0QAhceIQIXHwECFwwCASccMAEnHRgBJx6BAScfAQGXHEABlx0BAZcepgGXH5kBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -542,22 +410,17 @@
 					<key>AFGLowPowerState</key>
 					<data>AwAAAA==</data>
 					<key>Codec</key>
-					<string>Goldfish64 - ALC221 for HP Compaq Pro 4300/Pro 6300/Elite 8300</string>
+					<string>Goldfish64 - ALC221 for HP Compaq Pro 4300/Pro 6300/Elite 8300 (All Form Factors)</string>
 					<key>CodecID</key>
 					<integer>283902497</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccIAFHHUABRx4BAUcfAQFHDAIBdxwQAXcd
-					AQF3HhcBdx+QAXcMAgGnHEABpx0QAacegQGn
-					HwIBtxwwAbcdMAG3HoEBtx8BAhccUAIXHRAC
-					Fx4hAhcfAgIXDAI=
-					</data>
+					<data>AUccIAFHHUABRx4BAUcfAQFHDAIBdxwQAXcdAQF3HhcBdx+QAXcMAgGnHEABpx0QAacegQGnHwIBpwckAbccMAG3HTABtx6BAbcfAQIXHFACFx0QAhceIQIXHwICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
 					<integer>11</integer>
 					<key>WakeConfigData</key>
-					<data>AUcMAg==</data>
+					<data>AUcMAgF3DAIBpwckAhcMAg==</data>
 					<key>WakeVerbReinit</key>
 					<true/>
 				</dict>
@@ -569,12 +432,7 @@
 					<key>CodecID</key>
 					<integer>283902497</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccIAFHHUABRx4RAUcfkQFHDAIBpxwwAacd
-					EAGnHoEBpx8CAXccQAF3HQABdx4XAXcfkAG3
-					HFABtx0wAbcegQG3HwECFxxwAhcdEAIXHiEC
-					Fx8CAhcMAg==
-					</data>
+					<data>AUccIAFHHUABRx4RAUcfkQFHDAIBpxwwAacdEAGnHoEBpx8CAXccQAF3HQABdx4XAXcfkAG3HFABtx0wAbcegQG3HwECFxxwAhcdEAIXHiECFx8CAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -592,16 +450,7 @@
 					<key>CodecID</key>
 					<integer>283902501</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccUAEnHQEBJx6mAScftwE3HAABNx0AATce
-					AAE3H0ABRxywAUcdAQFHHhcBRx+QAWcc8AFn
-					HREBZx4RAWcfQQF3HPABdx0RAXceEQF3H0EB
-					hxzwAYcdEQGHHhEBhx9BAZccQAGXHRABlx6B
-					AZcfAQGnHPABpx0RAaceEQGnH0EBtxzwAbcd
-					EQG3HhEBtx9BAdccAQHXHQAB1x5gAdcfQAHn
-					HPAB5x0RAeceEQHnH0ECFxwgAhcdEAIXHiEC
-					Fx8EAUcMAg==
-					</data>
+					<data>ASccUAEnHQEBJx6mAScftwE3HAABNx0AATceAAE3H0ABRxywAUcdAQFHHhcBRx+QAWcc8AFnHREBZx4RAWcfQQF3HPABdx0RAXceEQF3H0EBhxzwAYcdEQGHHhEBhx9BAZccQAGXHRABlx6BAZcfAQGnHPABpx0RAaceEQGnH0EBtxzwAbcdEQG3HhEBtx9BAdccAQHXHQAB1x5gAdcfQAHnHPAB5x0RAeceEQHnH0ECFxwgAhcdEAIXHiECFx8EAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -619,11 +468,7 @@
 					<key>CodecID</key>
 					<integer>283902501</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6gAScfkAFHHEABRx0AAUce
-					FwFHH5ABlxxwAZcdEAGXHoEBlx8AAhccIAIX
-					HRACFx4hAhcfAAFHDAI=
-					</data>
+					<data>ASccMAEnHQABJx6gAScfkAFHHEABRx0AAUceFwFHH5ABlxxwAZcdEAGXHoEBlx8AAhccIAIXHRACFx4hAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -641,11 +486,7 @@
 					<key>CodecID</key>
 					<integer>283902501</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfmQG3HCABtx0AAbce
-					FwG3H5kBlxwwAZcdEAGXHoEBlx8CAhccQAIX
-					HRACFx4hAhcfAgG3DAIBRwwCAhcMAg==
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfmQG3HCABtx0AAbceFwG3H5kBlxwwAZcdEAGXHoEBlx8CAhccQAIXHRACFx4hAhcfAgG3DAIBRwwCAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -663,12 +504,7 @@
 					<key>CodecID</key>
 					<integer>283902512</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					FwFHH5ABlxwwAZcdEAGXHosBlx8EAhccQAIX
-					HRACFx4rAhcfBAE3HFABNx0AATceAAE3H0AB
-					1xxgAdcdsAHXHmYB1x9AAUcMAgGXDAI=
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHosBlx8EAhccQAIXHRACFx4rAhcfBAE3HFABNx0AATceAAE3H0AB1xxgAdcdsAHXHmYB1x9AAUcMAgGXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -682,11 +518,7 @@
 					<key>CodecID</key>
 					<integer>283902512</integer>
 					<key>ConfigData</key>
-					<data>
-					AhccEAIXHRACFx4rAhcfBAFHHCABRx0BAUce
-					FwFHH5ABJxwwAScdAQEnHqABJx+QAZccQAGX
-					HRABlx6LAZcfBAFHDAI=
-					</data>
+					<data>AhccEAIXHRACFx4rAhcfBAFHHCABRx0BAUceFwFHH5ABJxwwAScdAQEnHqABJx+QAZccQAGXHRABlx6LAZcfBAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -700,11 +532,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfkAGXHCABlx0QAZce
-					qwGXHwMBpxwwAacdAAGnHqABpx+QAhccQAIX
-					HRACFx4rAhcfAwFHDAI=
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfkAGXHCABlx0QAZceqwGXHwMBpxwwAacdAAGnHqABpx+QAhccQAIXHRACFx4rAhcfAwFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -722,10 +550,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfkAG3HCABtx0AAbce
-					oAG3H5ACFxwwAhcdEAIXHiECFx8BAUcMAg==
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfkAG3HCABtx0AAbceoAG3H5ACFxwwAhcdEAIXHiECFx8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -743,11 +568,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfkAGXHCABlx2QAZce
-					iwGXHwIBtxwwAbcdkAG3HqABtx+QAhccQAIX
-					HUACFx4rAhcfAgFHDAIBtwwC
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfkAGXHCABlx2QAZceiwGXHwIBtxwwAbcdkAG3HqABtx+QAhccQAIXHUACFx4rAhcfAgFHDAIBtwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -765,11 +586,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfmQIXHCACFx0QAhce
-					IQIXHwMBpxwwAacdAQGnHqABpx+ZAZccQAGX
-					HRABlx6BAZcfAw==
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfmQIXHCACFx0QAhceIQIXHwMBpxwwAacdAQGnHqABpx+ZAZccQAGXHRABlx6BAZcfAw==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -783,11 +600,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQEBRx4XAUcfkAGXHCABlx0QAZce
-					gQGXHwQBtxwwAbcdAQG3HqABtx+QAhccQAIX
-					HRACFx4hAhcfBAFHDAIBtwwCAhcMAg==
-					</data>
+					<data>AUccEAFHHQEBRx4XAUcfkAGXHCABlx0QAZcegQGXHwQBtxwwAbcdAQG3HqABtx+QAhccQAIXHRACFx4hAhcfBAFHDAIBtwwCAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -805,11 +618,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQEBJx6mAScfkAGnHDABpx1QAace
-					gQGnHwMBRxwQAUcdAQFHHhcBRx+QAUcMAgIX
-					HCACFx0QAhceIQIXHwMCFwwC
-					</data>
+					<data>ASccQAEnHQEBJx6mAScfkAGnHDABpx1QAacegQGnHwMBRxwQAUcdAQFHHhcBRx+QAUcMAgIXHCACFx0QAhceIQIXHwMCFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -827,12 +636,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx4AAScfQAFHHCABRx0AAUce
-					EwFHH5ABtxxAAbcdAAG3HqABtx+QAdccUAHX
-					HZAB1x5FAdcfQAIXHDACFx0QAhceIQIXHwAB
-					RwwCAhcMAg==
-					</data>
+					<data>ASccEAEnHQABJx4AAScfQAFHHCABRx0AAUceEwFHH5ABtxxAAbcdAAG3HqABtx+QAdccUAHXHZAB1x5FAdcfQAIXHDACFx0QAhceIQIXHwABRwwCAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -850,11 +654,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQEBRx4TAUcfmQGXHEABlx0QAZce
-					gQGXHwABpxwwAacdAQGnHqABpx+ZAhccIAIX
-					HRACFx4hAhcfAAFHDAI=
-					</data>
+					<data>AUccEAFHHQEBRx4TAUcfmQGXHEABlx0QAZcegQGXHwABpxwwAacdAQGnHqABpx+ZAhccIAIXHRACFx4hAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -872,11 +672,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					AaccMAGnHQABpx6nAacfkAGXHEABlx0QAZce
-					gQGXHwABRxxQAUcdAAFHHhcBRx+QAUcMAgIX
-					HGACFx0QAhceIQIXHwACFwwC
-					</data>
+					<data>AaccMAGnHQABpx6nAacfkAGXHEABlx0QAZcegQGXHwABRxxQAUcdAAFHHhcBRx+QAUcMAgIXHGACFx0QAhceIQIXHwACFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -894,11 +690,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					AhccIAIXHRACFx4hAhcfAAIXDAIBtxwwAbcd
-					AAG3HqcBtx+QAZccQAGXHRABlx6BAZcfAAFH
-					HFABRx0AAUceFwFHH5ABRwwC
-					</data>
+					<data>AhccIAIXHRACFx4hAhcfAAIXDAIBtxwwAbcdAAG3HqcBtx+QAZccQAGXHRABlx6BAZcfAAFHHFABRx0AAUceFwFHH5ABRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -916,12 +708,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					FwFHH5ABdxwwAXcdAAF3HgABdx9AAZccQAGX
-					HRABlx6LAZcfAAHXHFAB1x2QAdce9wHXH0AC
-					FxxgAhcdEAIXHisCFx8BAUcMAgIXDAI=
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABdxwwAXcdAAF3HgABdx9AAZccQAGXHRABlx6LAZcfAAHXHFAB1x2QAdce9wHXH0ACFxxgAhcdEAIXHisCFx8BAUcMAgIXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -939,14 +726,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHAEBJxygAScckAFHHAABRxwBAUcc
-					EAFHHJABlxwwAZccEAGXHIEBlxwCAhccIAIX
-					HBACFxwhAhccAgF3HPABdx0AAXceAAF3H0AB
-					hxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4A
-					AacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcd
-					AAHXHgAB1x9AAUcMAg==
-					</data>
+					<data>ASccEAEnHAEBJxygAScckAFHHAABRxwBAUccEAFHHJABlxwwAZccEAGXHIEBlxwCAhccIAIXHBACFxwhAhccAgF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -964,15 +744,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQEBJx6mAScfkAFHHBABRx0BAUce
-					FwFHH5ABlxxAAZcdEAGXHoEBlx8EAhccMAIX
-					HRACFx4hAhcfBAF3HPABdx0AAXceAAF3H0AB
-					hxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4A
-					AacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcd
-					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFH
-					DAICFwwC
-					</data>
+					<data>ASccIAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABlxxAAZcdEAGXHoEBlx8EAhccMAIXHRACFx4hAhcfBAF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -990,11 +762,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQABJx6gAScfsAFHHBABRx0AAUce
-					FwFHH5ABRwwCAZccMAGXHRABlx6BAZcfAAIX
-					HGACFx0QAhceIQIXHwA=
-					</data>
+					<data>ASccQAEnHQABJx6gAScfsAFHHBABRx0AAUceFwFHH5ABRwwCAZccMAGXHRABlx6BAZcfAAIXHGACFx0QAhceIQIXHwA=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1012,16 +780,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccAAG3HQEBtx6gAbcfmQIXHBACFx0QAhce
-					KwIXHwEBRxwgAUcdAQFHHhABRx+ZAZccMAGX
-					HRABlx6LAZcfAQEnHPABJx0AASceAAEnH0AB
-					dxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4A
-					AYcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcd
-					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAHX
-					HPAB1x0AAdceAAHXH0AB1xzwAdcdAAHXHgAB
-					1x9A
-					</data>
+					<data>AbccAAG3HQEBtx6gAbcfmQIXHBACFx0QAhceKwIXHwEBRxwgAUcdAQFHHhABRx+ZAZccMAGXHRABlx6LAZcfAQEnHPABJx0AASceAAEnH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAHXHPAB1x0AAdceAAHXH0AB1xzwAdcdAAHXHgAB1x9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1037,11 +796,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					AhccIAIXHRACFx4rAhcfAAG3HDABtx0AAbce
-					pwG3H5ABlxwwAZcdEAGXHosBlx8BAUccQAFH
-					HQABRx4XAUcfkAFHDAI=
-					</data>
+					<data>AhccIAIXHRACFx4rAhcfAAG3HDABtx0AAbcepwG3H5ABlxwwAZcdEAGXHosBlx8BAUccQAFHHQABRx4XAUcfkAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1059,11 +814,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQEBRx4XAUcfkAFHDAICFxwfAhcd
-					EAIXHiECFx8CAhcMAgGXHCABlx0QAZceoAGX
-					H5IBpxwwAacdEAGnHoABpx8C
-					</data>
+					<data>AUccEAFHHQEBRx4XAUcfkAFHDAICFxwfAhcdEAIXHiECFx8CAhcMAgGXHCABlx0QAZceoAGXH5IBpxwwAacdEAGnHoABpx8C</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1081,15 +832,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUce
-					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHDABlx0QAZceiwGXHwIB
-					pxwQAacdAQGnHqABpx+QAbccIAG3HQEBtx4X
-					AbcfkAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccQAIXHRACFx4rAhcfAgG3
-					DAICFwwC
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHDABlx0QAZceiwGXHwIBpxwQAacdAQGnHqABpx+QAbccIAG3HQEBtx4XAbcfkAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccQAIXHRACFx4rAhcfAgG3DAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1107,11 +850,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccEAG3HQABtx6gAbcfkAFHHCABRx0AAUce
-					FwFHH5ABlxwwAZcdEAGXHoEBlx8AAhccQAIX
-					HRACFx4hAhcfAQFHDAICFwwC
-					</data>
+					<data>AbccEAG3HQABtx6gAbcfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHoEBlx8AAhccQAIXHRACFx4hAhcfAQFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1129,11 +868,7 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQABJx6gAScfsAFHHBABRx0AAUce
-					FwFHH5ABRwwCAZccMAGXHRABlx6BAZcfAAIX
-					HGACFx0QAhceIQIXHwA=
-					</data>
+					<data>ASccQAEnHQABJx6gAScfsAFHHBABRx0AAUceFwFHH5ABRwwCAZccMAGXHRABlx6BAZcfAAIXHGACFx0QAhceIQIXHwA=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1151,11 +886,7 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
-					FwFHH5ABlxwwAZcdEAGXHoEBlx8EAhccQAIX
-					HRACFx4hAhcfBAFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHoEBlx8EAhccQAIXHRACFx4hAhcfBAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1173,15 +904,7 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwwAUcdAQFHHhABRx+QAUcMAgGH
-					HPABhx0AAYceAAGHH0ABlxwgAZcdMAGXHosB
-					lx8BAacc8AGnHQABpx4AAacfQAG3HPABtx0A
-					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHEACFx1AAhceKwIX
-					HwECFwwCABcgAAAXIXIAFyJrABcjEA==
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxwwAUcdAQFHHhABRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwgAZcdMAGXHosBlx8BAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHEACFx1AAhceKwIXHwECFwwCABcgAAAXIXIAFyJrABcjEA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1199,11 +922,7 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUce
-					EAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAQIX
-					HFACFx0QAhceKwIXHwECFwwC
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUceEAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAQIXHFACFx0QAhceKwIXHwECFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1219,15 +938,7 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUce
-					EAFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHCABlx2QAZceqwGXHwAB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccMAIXHUACFx4rAhcfAAFH
-					DAI=
-					</data>
+					<data>ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUceEAFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHCABlx2QAZceqwGXHwABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHUACFx4rAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1245,11 +956,7 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUce
-					EAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAAIX
-					HDACFx0QAhceKwIXHwACFwwC
-					</data>
+					<data>ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUceEAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAAIXHDACFx0QAhceKwIXHwACFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1267,15 +974,7 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwgAUcdkAFHHhcBRx+QAUcMAgGH
-					HPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHosB
-					lx8BAacc8AGnHQABpx4AAacfQAG3HPABtx0A
-					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHBACFx0QAhceKwIX
-					HwECFwwC
-					</data>
+					<data>ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwgAUcdkAFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHosBlx8BAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHBACFx0QAhceKwIXHwECFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1293,11 +992,7 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUce
-					EAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAAIX
-					HDACFx0QAhceKwIXHwABRwwCAhcMAg==
-					</data>
+					<data>ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUceEAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAAIXHDACFx0QAhceKwIXHwABRwwCAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1315,15 +1010,7 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGH
-					HPABhx0AAYceAAGHH0ABlxzwAZcdEQGXHhEB
-					lx9BAacc8AGnHQABpx4AAacfQAG3HPABtx0A
-					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIX
-					HwICFwwC
-					</data>
+					<data>ASccQAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxzwAZcdEQGXHhEBlx9BAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIXHwICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1341,14 +1028,7 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>
-					ATcc8AE3HQABNx4AATcfQAFHHBABRx0BAUce
-					FwFHH5ABRwwCAYcc8AGHHQABhx4AAYcfQAGX
-					HDABlx0QAZcegQGXHwQBpxzwAacdAAGnHgAB
-					px9AAbcc8AG3HQABtx4AAbcfQAHXHEUB1x0b
-					AdceZgHXH0AB5xzwAecdAAHnHgAB5x9AAhcc
-					HwIXHRACFx4hAhcfBA==
-					</data>
+					<data>ATcc8AE3HQABNx4AATcfQAFHHBABRx0BAUceFwFHH5ABRwwCAYcc8AGHHQABhx4AAYcfQAGXHDABlx0QAZcegQGXHwQBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHEUB1x0bAdceZgHXH0AB5xzwAecdAAHnHgAB5x9AAhccHwIXHRACFx4hAhcfBA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1366,11 +1046,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
-					FwFHH5ABlxwwAZcdEAGXHosBlx8AAhccUAIX
-					HRACFx4rAhcfAgFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHosBlx8AAhccUAIXHRACFx4rAhcfAgFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1388,15 +1064,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHEABlx0QAZceiwGXHwIB
-					pxzwAacdAAGnHgABpx9AAbccIAG3HRABtx4B
-					AbcfAQHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccMAIXHRACFx4rAhcfAgFH
-					DAI=
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHEABlx0QAZceiwGXHwIBpxzwAacdAAGnHgABpx9AAbccIAG3HRABtx4BAbcfAQHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRACFx4rAhcfAgFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1414,11 +1082,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccIAG3HQABtx6gAbcfkAFHHDABRx0AAUce
-					FwFHH5ACFxxQAhcdEAIXHiECFx8AAUcMAgIX
-					DAI=
-					</data>
+					<data>AbccIAG3HQABtx6gAbcfkAFHHDABRx0AAUceFwFHH5ACFxxQAhcdEAIXHiECFx8AAUcMAgIXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1436,10 +1100,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6gAScfkAGXHCABlx0RAZce
-					gQGXHwICFxxAAhcdEQIXHiECFx8CAhcMAg==
-					</data>
+					<data>ASccMAEnHQEBJx6gAScfkAGXHCABlx0RAZcegQGXHwICFxxAAhcdEQIXHiECFx8CAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1457,12 +1118,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
-					FwFHH5ABdxwwAXcdAAF3HgABdx9AAdccQAHX
-					HQAB1x5wAdcfQAIXHFACFx0QAhceIQIXHwIB
-					RwwC
-					</data>
+					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABdxwwAXcdAAF3HgABdx9AAdccQAHXHQAB1x5wAdcfQAIXHFACFx0QAhceIQIXHwIBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1480,13 +1136,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
-					FwFHH5ABtxwhAbcdAAG3HhcBtx+QAXccMAF3
-					HQABdx4AAXcfQAHXHEAB1x0AAdcecAHXH0AC
-					FxxQAhcdEAIXHiECFx8CAaccYAGnHRABpx6B
-					AacfAgHnHHAB5x0QAeceRQHnHwIBRwwC
-					</data>
+					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABtxwhAbcdAAG3HhcBtx+QAXccMAF3HQABdx4AAXcfQAHXHEAB1x0AAdcecAHXH0ACFxxQAhcdEAIXHiECFx8CAaccYAGnHRABpx6BAacfAgHnHHAB5x0QAeceRQHnHwIBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1504,11 +1154,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					AZcc8AGXHRABlx6BAZcfAgGnHDABpx0BAace
-					oAGnH5ABtxwQAbcdAQG3HhcBtx+QAhccIAIX
-					HRACFx4hAhcfAgG3DAICFwwC
-					</data>
+					<data>AZcc8AGXHRABlx6BAZcfAgGnHDABpx0BAaceoAGnH5ABtxwQAbcdAQG3HhcBtx+QAhccIAIXHRACFx4hAhcfAgG3DAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1526,11 +1172,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQEBRx4XAUcfkAGXHCABlx0QAZce
-					gQGXHwQCFxwgAhcdEAIXHiECFx8EAbccMAG3
-					HQEBtx6gAbcfkAFHDAI=
-					</data>
+					<data>AUccEAFHHQEBRx4XAUcfkAGXHCABlx0QAZcegQGXHwQCFxwgAhcdEAIXHiECFx8EAbccMAG3HQEBtx6gAbcfkAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1548,10 +1190,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccYAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					FwFHH5ABRwwCAhccMAIXHRACFx4hAhcfAQ==
-					</data>
+					<data>ASccYAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABRwwCAhccMAIXHRACFx4hAhcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1569,15 +1208,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUce
-					FwFHH5ABRwwCAXccAAF3HQABdx4AAXcfQAGH
-					HPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHoEB
-					lx8EAacc8AGnHQABpx4AAacfQAG3HPABtx0A
-					AbceAAG3H0AB1xwtAdcdmgHXHvcB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIX
-					HwQCFwwC
-					</data>
+					<data>ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABRwwCAXccAAF3HQABdx4AAXcfQAGHHPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHoEBlx8EAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xwtAdcdmgHXHvcB1x9AAecc8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIXHwQCFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1595,11 +1226,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfkAFHDAICFxwgAhcd
-					EAIXHiECFx8AAhcMAgEnHDABJx0AAScepgEn
-					H5ABlxxAAZcdAAGXHoEBlx8A
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfkAFHDAICFxwgAhcdEAIXHiECFx8AAhcMAgEnHDABJx0AAScepgEnH5ABlxxAAZcdAAGXHoEBlx8A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1617,11 +1244,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQEBJx6mAScfkAFHHCABRx0BAUce
-					FwFHH5ABRwwCAZcccAGXHRABlx6LAZcfAgIX
-					HDACFx0QAhceIQIXHwICFwwC
-					</data>
+					<data>ASccQAEnHQEBJx6mAScfkAFHHCABRx0BAUceFwFHH5ABRwwCAZcccAGXHRABlx6LAZcfAgIXHDACFx0QAhceIQIXHwICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1639,15 +1262,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUce
-					FwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGH
-					HPABhx0AAYceAAGHH0ABlxxwAZcdEAGXHosB
-					lx8CAacc8AGnHQABpx4AAacfQAG3HPABtx0A
-					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHCACFx0QAhceKwIX
-					HwQCFwwC
-					</data>
+					<data>ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGHHPABhx0AAYceAAGHH0ABlxxwAZcdEAGXHosBlx8CAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHCACFx0QAhceKwIXHwQCFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1665,15 +1280,7 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgF3
-					HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgAB
-					hx9AAZccEAGXHRABlx6LAZcfAgGnHPABpx0A
-					AaceAAGnH0ABtxzwAbcdAAG3HgABtx9AAdcc
-					8AHXHQAB1x4AAdcfQAHnHJAB5x3gAeceRQHn
-					HwECFxwwAhcdEAIXHisCFx8CAhcMAg==
-					</data>
+					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAZccEAGXHRABlx6LAZcfAgGnHPABpx0AAaceAAGnH0ABtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHJAB5x3gAeceRQHnHwECFxwwAhcdEAIXHisCFx8CAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1691,15 +1298,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHCABRx0AAUce
-					FwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIX
-					HRACFx4rAhcfAgE3HPABNx0AATceAAE3H0AB
-					hxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4A
-					AacfQAG3HDABtx0AAbceoAG3H5AB1xzwAdcd
-					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFH
-					DAIBtwwC
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIXHRACFx4rAhcfAgE3HPABNx0AATceAAE3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAG3HDABtx0AAbceoAG3H5AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFHDAIBtwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1717,10 +1316,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccAAEnHQEBJx6mAScfmQFHHBABRx0BAUce
-					FwFHH5kCFxwgAhcdEAIXHiECFx8BAbcMAg==
-					</data>
+					<data>ASccAAEnHQEBJx6mAScfmQFHHBABRx0BAUceFwFHH5kCFxwgAhcdEAIXHiECFx8BAbcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1738,15 +1334,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					FwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIX
-					HRACFx4rAhcfAgE3HPABNx0AATceAAE3H0AB
-					hxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4A
-					AacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcd
-					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFH
-					DAI=
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIXHRACFx4rAhcfAgE3HPABNx0AATceAAE3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1764,15 +1352,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					FwFHH5ABRwwCAZccMAGXHRABlx6LAZcfAgG3
-					HEABtx0AAbceFwG3H5ABtwwCAhccUAIXHRAC
-					Fx4rAhcfAgE3HPABNx0AATceAAE3H0ABhxzw
-					AYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacf
-					QAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHn
-					HgAB5x9A
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABRwwCAZccMAGXHRABlx6LAZcfAgG3HEABtx0AAbceFwG3H5ABtwwCAhccUAIXHRACFx4rAhcfAgE3HPABNx0AATceAAE3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1790,15 +1370,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccYAEnHAEBJxymAScckAE3HPABNx0AATce
-					AAE3H0ABRxxAAUcdAQFHHhABRx+QAUcMAgGH
-					HPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHosB
-					lx8BAacccAGnHQABpx6hAacfAQG3HEEBtx0B
-					AbceEAG3H5ABtwwCAdcc8AHXHQAB1x4AAdcf
-					QAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIX
-					HisCFx8BAhcMAg==
-					</data>
+					<data>ASccYAEnHAEBJxymAScckAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhABRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHosBlx8BAacccAGnHQABpx6hAacfAQG3HEEBtx0BAbceEAG3H5ABtwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIXHisCFx8BAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1816,11 +1388,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUce
-					FwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIX
-					HRACFx4rAhcfAgFHDAICFwwCAZcHJQIXCIM=
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUceFwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIXHRACFx4rAhcfAgFHDAICFwwCAZcHJQIXCIM=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1838,10 +1406,7 @@
 					<key>Comment</key>
 					<string>Andres ZeroCross for Asus VivoBook Pro 17  N705UDR</string>
 					<key>ConfigData</key>
-					<data>
-					AbccUAG3HQEBtx4XAbcfkAGnHDABpx0BAace
-					oAGnH5ACFxwgAhcdEAIXHiECFx8DAbcMAg==
-					</data>
+					<data>AbccUAG3HQEBtx4XAbcfkAGnHDABpx0BAaceoAGnH5ACFxwgAhcdEAIXHiECFx8DAbcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1859,11 +1424,7 @@
 					<key>Comment</key>
 					<string>Andres ZeroCross for Razer Blade 15 RZ09-02705E75</string>
 					<key>ConfigData</key>
-					<data>
-					AUccUAFHHQABRx4XAUcfkAFHDAIBJxwwAScd
-					AAEnHqABJx+QAhccIAIXHRACFx4hAhcfAAGX
-					HEABlx0QAZcegQGXHwQ=
-					</data>
+					<data>AUccUAFHHQABRx4XAUcfkAFHDAIBJxwwAScdAAEnHqABJx+QAhccIAIXHRACFx4hAhcfAAGXHEABlx0QAZcegQGXHwQ=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1881,10 +1442,7 @@
 					<key>Comment</key>
 					<string>vusun123 - ALC256 for Asus X555UJ</string>
 					<key>ConfigData</key>
-					<data>
-					AUccUAFHHQABRx4XAUcfkAFHDAIBpxwwAacd
-					AAGnHqABpx+QAhccIAIXHRACFx4hAhcfAA==
-					</data>
+					<data>AUccUAFHHQABRx4XAUcfkAFHDAIBpxwwAacdAAGnHqABpx+QAhccIAIXHRACFx4hAhcfAA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1902,15 +1460,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGH
-					HPABhx0AAYceAAGHH0ABlxxAAZcdEAGXHoEB
-					lx8CAacc8AGnHQABpx4AAacfQAG3HPABtx0A
-					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIX
-					HwICFwwC
-					</data>
+					<data>ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxxAAZcdEAGXHoEBlx8CAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIXHwICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1928,15 +1478,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					AScccAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxzwAUcdAAFHHgABRx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHDABlx0QAZceiwGXHwIB
-					pxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4Q
-					AbcfkAG3DAIB1xzwAdcdAAHXHgAB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHFACFx0QAhceKwIX
-					HwICFwwC
-					</data>
+					<data>AScccAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAYcc8AGHHQABhx4AAYcfQAGXHDABlx0QAZceiwGXHwIBpxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4QAbcfkAG3DAIB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHFACFx0QAhceKwIXHwICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1954,15 +1496,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAE3HPABNx0AATce
-					AAE3H0ABRxwgAUcdAQFHHhcBRx+QAUcMAgGH
-					HPABhx0AAYceAAGHH0ABlxwwAZcdEAGXHosB
-					lx8CAacc8AGnHQABpx4AAacfQAG3HDABtx0A
-					AbceoAG3H5ABtwwCAdcc8AHXHQAB1x4AAdcf
-					QAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIX
-					HisCFx8CAhcMAgGXByQBtwckAhcIgw==
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAE3HPABNx0AATceAAE3H0ABRxwgAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwwAZcdEAGXHosBlx8CAacc8AGnHQABpx4AAacfQAG3HDABtx0AAbceoAG3H5ABtwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIXHisCFx8CAhcMAgGXByQBtwckAhcIgw==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1980,15 +1514,7 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwRAUcdAQFHHhcBRx+QAUcMAgGH
-					HPABhx0AAYceAAGHH0ABlxxAAZcdEAGXHoEB
-					lx8EAacc8AGnHQABpx4AAacfQAG3HBABtx0B
-					AbceFwG3H5ABtwwCAdcc8AHXHQAB1x4AAdcf
-					QAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIX
-					HiECFx8EAhcMAg==
-					</data>
+					<data>ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwRAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxxAAZcdEAGXHoEBlx8EAacc8AGnHQABpx4AAacfQAG3HBABtx0BAbceFwG3H5ABtwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIXHiECFx8EAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2006,11 +1532,7 @@
 					<key>CodecID</key>
 					<integer>283902551</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQABJx6mAScfkAGXHDABlx0QAZce
-					gQGXHwABRxxQAUcdAAFHHhcBRx+QAUcMAgIX
-					HGACFx0QAhceIQIXHwA=
-					</data>
+					<data>ASccIAEnHQABJx6mAScfkAGXHDABlx0QAZcegQGXHwABRxxQAUcdAAFHHhcBRx+QAUcMAgIXHGACFx0QAhceIQIXHwA=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2028,15 +1550,7 @@
 					<key>CodecID</key>
 					<integer>283902551</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGH
-					HPABhx0AAYceAAGHH0ABlxwwAZcdEAGXHosB
-					lx8EAacc8AGnHQABpx4AAacfQAG3HPABtx0A
-					AbceAAG3H0ABtwwCAdcc8AHXHQAB1x4AAdcf
-					QAHnHPAB5x0AAeceAAHnH0ACFxwfAhcdEAIX
-					HisCFx8EAhcMAg==
-					</data>
+					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwwAZcdEAGXHosBlx8EAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0ABtwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxwfAhcdEAIXHisCFx8EAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2054,12 +1568,7 @@
 					<key>CodecID</key>
 					<integer>283902560</integer>
 					<key>ConfigData</key>
-					<data>
-					IPccECD3HUAg9x4RIPcfASD3DAIhhxwgIYcd
-					YCGHHkQhhx8BITccQCE3HZAhNx6hITcfmSFH
-					HFAhRx0wIUcegSFHHwEhVxxgIVcdQCFXHiEh
-					Vx8C
-					</data>
+					<data>IPccECD3HUAg9x4RIPcfASD3DAIhhxwgIYcdYCGHHkQhhx8BITccQCE3HZAhNx6hITcfmSFHHFAhRx0wIUcegSFHHwEhVxxgIVcdQCFXHiEhVx8C</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2073,10 +1582,7 @@
 					<key>CodecID</key>
 					<integer>283902560</integer>
 					<key>ConfigData</key>
-					<data>
-					AQccAAEHHUABBx4hAQcfAQEnHBABJx2QASce
-					oQEnH5kBNxwgATcdMAE3HoEBNx8B
-					</data>
+					<data>AQccAAEHHUABBx4hAQcfAQEnHBABJx2QASceoQEnH5kBNxwgATcdMAE3HoEBNx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2090,11 +1596,7 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>
-					AVccYAFXHUABVx4BAVcfAQFHHFABRx1AAUce
-					IQFHHwEBhxwgAYcdMAGHHoEBhx8BAaccEAGn
-					HZABpx6iAacfAQ==
-					</data>
+					<data>AVccYAFXHUABVx4BAVcfAQFHHFABRx1AAUceIQFHHwEBhxwgAYcdMAGHHoEBhx8BAaccEAGnHZABpx6iAacfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2108,12 +1610,7 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4BIUcfASHnHCAh5x1gIece
-					RSHnHwAhhxwwIYcdkCGHHqEhhx+RIZccQCGX
-					HZAhlx6hIZcfkiGnHFAhpx0wIacegSGnHwEh
-					txxgIbcdQCG3HiEhtx8C
-					</data>
+					<data>IUccECFHHUAhRx4BIUcfASHnHCAh5x1gIeceRSHnHwAhhxwwIYcdkCGHHqEhhx+RIZccQCGXHZAhlx6hIZcfkiGnHFAhpx0wIacegSGnHwEhtxxgIbcdQCG3HiEhtx8C</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2127,11 +1624,7 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccEAG3HUABtx4BAbcfAQFXHCABVx0QAVce
-					IQFXHwIBZxwwAWcdAQFnHhMBZx+QAZccQAGX
-					HTABlx6BAZcfAQGnHFABpx0QAacegQGnHwI=
-					</data>
+					<data>AbccEAG3HUABtx4BAbcfAQFXHCABVx0QAVceIQFXHwIBZxwwAWcdAQFnHhMBZx+QAZccQAGXHTABlx6BAZcfAQGnHFABpx0QAacegQGnHwI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2145,11 +1638,7 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAFXHCABVx0QAVce
-					IQFXHwIBhxwwAYcdEAGHHoEBhx8CAZccQAGX
-					HQABlx6jAZcfkAGnHFABpx0QAacegQGnHwE=
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAFXHCABVx0QAVceIQFXHwIBhxwwAYcdEAGHHoEBhx8CAZccQAGXHQABlx6jAZcfkAGnHFABpx0QAacegQGnHwE=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2163,12 +1652,7 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>
-					AZccAAGXHREBlx6gAZcfkgGnHBABpx0xAace
-					gAGnH5EBVxwgAVcdQQFXHhABVx+RAWccMAFn
-					HQEBZx4AAWcfKQGHHEABhx2QAYceoAGHH5EB
-					txxQAbcdEAG3HisBtx8C
-					</data>
+					<data>AZccAAGXHREBlx6gAZcfkgGnHBABpx0xAacegAGnH5EBVxwgAVcdQQFXHhABVx+RAWccMAFnHQEBZx4AAWcfKQGHHEABhx2QAYceoAGHH5EBtxxQAbcdEAG3HisBtx8C</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2182,11 +1666,7 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4hAUcfAgFXHB8BVx0QAVce
-					AQFXHwEBZxwgAWcdAQFnHhMBZx+ZAYccMAGH
-					HTABhx6BAYcfAQGnHD8Bpx2QAaceoQGnHwI=
-					</data>
+					<data>AUccEAFHHUABRx4hAUcfAgFXHB8BVx0QAVceAQFXHwEBZxwgAWcdAQFnHhMBZx+ZAYccMAGHHTABhx6BAYcfAQGnHD8Bpx2QAaceoQGnHwI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2200,11 +1680,7 @@
 					<key>CodecID</key>
 					<integer>283902568</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHRABRx4hAUcfAQGHHEABhx2QAYce
-					gQGHHwEBVxxQAVcdAAFXHhMBVx+QAZccYAGX
-					HQABlx6jAZcfkAFXDAI=
-					</data>
+					<data>AUccEAFHHRABRx4hAUcfAQGHHEABhx2QAYcegQGHHwEBVxxQAVcdAAFXHhMBVx+QAZccYAGXHQABlx6jAZcfkAFXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2218,11 +1694,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AYccIAGHHRABhx6BAYcfBAGXHBABlx0BAZce
-					oAGXH5kBtxxAAbcdAQG3HhMBtx+ZAhccUAIX
-					HRACFx4hAhcfBAFHDAI=
-					</data>
+					<data>AYccIAGHHRABhx6BAYcfBAGXHBABlx0BAZceoAGXH5kBtxxAAbcdAQG3HhMBtx+ZAhccUAIXHRACFx4hAhcfBAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2240,11 +1712,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccQAFHHQEBRx4TAUcfmQGHHCABhx0QAYce
-					gQGHHwMBlxwQAZcdAQGXHqABlx+ZAhccUAIX
-					HRACFx4hAhcfAwFHDAI=
-					</data>
+					<data>AUccQAFHHQEBRx4TAUcfmQGHHCABhx0QAYcegQGHHwMBlxwQAZcdAQGXHqABlx+ZAhccUAIXHRACFx4hAhcfAwFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2264,15 +1732,7 @@
 					<key>Comment</key>
 					<string>Mirone - Realtek ALC269 for Asus K53SJ, Asus G73s</string>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
-					EwFHH5ABdxxQAXcdAQF3HhMBdx+QAYccIAGH
-					HZABhx6BAYcfAwGXHDABlx0BAZceoAGXH5AB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAwFH
-					DAI=
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceEwFHH5ABdxxQAXcdAQF3HhMBdx+QAYccIAGHHZABhx6BAYcfAwGXHDABlx0BAZceoAGXH5ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAwFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2290,11 +1750,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAGHHCABhx2QAYce
-					gQGHHwIBtxwwAbcdEAG3HqABtx+QAhccQAIX
-					HRACFx4hAhcfAgFHDAI=
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAGHHCABhx2QAYcegQGHHwIBtxwwAbcdEAG3HqABtx+QAhccQAIXHRACFx4hAhcfAgFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2312,11 +1768,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					EwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIX
-					HRACFx4hAhcfAAFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2334,11 +1786,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAGHHDABhx0QAYce
-					gQGHHwABJxxAAScdAAEnHqABJx+QAVccUAFX
-					HRABVx4hAVcfAAFHDAI=
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAGHHDABhx0QAYcegQGHHwABJxxAAScdAAEnHqABJx+QAVccUAFXHRABVx4hAVcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2356,11 +1804,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfkAFXHCABVx0QAVce
-					IQFXHwABhxwwAYcdEAGHHoEBhx8CAbccQAG3
-					HQABtx4XAbcfkAG3DAI=
-					</data>
+					<data>ASccEAEnHQABJx6mAScfkAFXHCABVx0QAVceIQFXHwABhxwwAYcdEAGHHoEBhx8CAbccQAG3HQABtx4XAbcfkAG3DAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2374,11 +1818,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
-					FwFHH5ABVxwwAVcdEAFXHiEBVx8AAYccQAGH
-					HZABhx6BAYcfAgFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABVxwwAVcdEAFXHiEBVx8AAYccQAGHHZABhx6BAYcfAgFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2396,11 +1836,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					EwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIX
-					HRACFx4hAhcfAAFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2418,14 +1854,7 @@
 					<key>Comment</key>
 					<string>Toleda ALC269 patch for Brix</string>
 					<key>ConfigData</key>
-					<data>
-					IUcc8CFHHQAhRx4AIUcfQCFXHHAhVx1AIVce
-					ISFXHwIhZxzwIWcdACFnHgAhZx9AIXcc8CF3
-					HQAhdx4AIXcfQCGHHPAhhx0AIYceACGHH0Ah
-					lxzwIZcdACGXHgAhlx9AIacc8CGnHQAhpx4A
-					IacfQCG3HPAhtx0AIbceACG3H0Ah5xyQIecd
-					YSHnHksh5x8B
-					</data>
+					<data>IUcc8CFHHQAhRx4AIUcfQCFXHHAhVx1AIVceISFXHwIhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHPAhhx0AIYceACGHH0AhlxzwIZcdACGXHgAhlx9AIacc8CGnHQAhpx4AIacfQCG3HPAhtx0AIbceACG3H0Ah5xyQIecdYSHnHksh5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2439,11 +1868,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccIAG3HUABtx4BAbcfAQGHHDABhx2YAYce
-					gQGHHwIBlxxAAZcdmAGXHoEBlx8BAhccUAIX
-					HUACFx4hAhcfAg==
-					</data>
+					<data>AbccIAG3HUABtx4BAbcfAQGHHDABhx2YAYcegQGHHwIBlxxAAZcdmAGXHoEBlx8BAhccUAIXHUACFx4hAhcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2457,15 +1882,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
-					pxwgAacdEAGnHisBpx8AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhcc8AIXHQACFx4AAhcfQAFH
-					DAI=
-					</data>
+					<data>ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxwgAacdEAGnHisBpx8AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhcc8AIXHQACFx4AAhcfQAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2483,11 +1900,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AZccEAGXHQABlx6nAZcfmQFXHCABVx0QAVce
-					IQFXHwIBhxwwAYcdEAGHHoEBhx8CAUccQAFH
-					HQABRx4XAUcfmQFHDAI=
-					</data>
+					<data>AZccEAGXHQABlx6nAZcfmQFXHCABVx0QAVceIQFXHwIBhxwwAYcdEAGHHoEBhx8CAUccQAFHHQABRx4XAUcfmQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2505,15 +1918,7 @@
 					<key>Comment</key>
 					<string>Custom ALC269VC for Samsung NT550P7C-S65 with subwoofer 2.1ch by Rockjesus</string>
 					<key>ConfigData</key>
-					<data>
-					AVccEAFXHRABVx4hAVcfAQGHHCABhx0QAYce
-					gQGHHwEBlxwwAZcdAQGXHqcBlx+QAbccQAG3
-					HQEBtx4XAbcfkAF3HEEBdx0BAXceFwF3H5AB
-					JxzwAScdAAEnHgABJx9AAUcc8AFHHQABRx4A
-					AUcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcd
-					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAG3
-					DAI=
-					</data>
+					<data>AVccEAFXHRABVx4hAVcfAQGHHCABhx0QAYcegQGHHwEBlxwwAZcdAQGXHqcBlx+QAbccQAG3HQEBtx4XAbcfkAF3HEEBdx0BAXceFwF3H5ABJxzwAScdAAEnHgABJx9AAUcc8AFHHQABRx4AAUcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAG3DAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2527,11 +1932,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccIAG3HUABtx4BAbcfAQGHHDABhx2QAYce
-					gQGHHwIBlxxAAZcdkAGXHoEBlx8BAhccUAIX
-					HUACFx4hAhcfAg==
-					</data>
+					<data>AbccIAG3HUABtx4BAbcfAQGHHDABhx2QAYcegQGHHwIBlxxAAZcdkAGXHoEBlx8BAhccUAIXHUACFx4hAhcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2545,11 +1946,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccIAG3HUABtx4RAbcfkAGHHDABhx2QAYce
-					oQGHH5ABlxxAAZcdkAGXHoEBlx8BAhccUAIX
-					HUACFx4hAhcfAg==
-					</data>
+					<data>AbccIAG3HUABtx4RAbcfkAGHHDABhx2QAYceoQGHH5ABlxxAAZcdkAGXHoEBlx8BAhccUAIXHUACFx4hAhcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2563,10 +1960,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AYccIAGHHVABhx6hAYcfkQFXHDABVx1AAVce
-					IQFXHwEBVwwC
-					</data>
+					<data>AYccIAGHHVABhx6hAYcfkQFXHDABVx1AAVceIQFXHwEBVwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2584,11 +1978,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUce
-					EAFHH5ABVxxQAVcdEAFXHiEBVx8BAYcccAGH
-					HRABhx6hAYcfAQFHDAI=
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUceEAFHH5ABVxxQAVcdEAFXHiEBVx8BAYcccAGHHRABhx6hAYcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2606,15 +1996,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccIAIXHRACFx4rAhcfAAFH
-					DAI=
-					</data>
+					<data>ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccIAIXHRACFx4rAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2634,11 +2016,7 @@
 					<key>Comment</key>
 					<string>Custom ALC269 Sony Vaio VPCEB3M1R by Rodion</string>
 					<key>ConfigData</key>
-					<data>
-					AVccQAFXHRABVx4hAVcfAwGHHCABhx0QAYce
-					gQGHHwMBlxwwAZcdAQGXHqABlx+QAbccEAG3
-					HQEBtx4XAbcfkAFXDAI=
-					</data>
+					<data>AVccQAFXHRABVx4hAVcfAwGHHCABhx0QAYcegQGHHwMBlxwwAZcdAQGXHqABlx+QAbccEAG3HQEBtx4XAbcfkAFXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2652,15 +2030,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
-					EwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGH
-					HDABhx2QAYcegQGHHwIBlxxAAZcdkAGXHoEB
-					lx8BAacc8AGnHQABpx4AAacfQAG3HCABtx1A
-					AbceAQG3HwEB1xzwAdcdAAHXHgAB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHFACFx1AAhceIQIX
-					HwI=
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceEwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGHHDABhx2QAYcegQGHHwIBlxxAAZcdkAGXHoEBlx8BAacc8AGnHQABpx4AAacfQAG3HCABtx1AAbceAQG3HwEB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHFACFx1AAhceIQIXHwI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2676,11 +2046,7 @@
 					<key>Comment</key>
 					<string>Custom ALC269 for Acer Aspire by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>
-					AUccAAFHHUEBRx4XAUcfmQGHHBABhx2QAYce
-					gQGHHwEBtxwgAbcdkQG3HqcBtx+ZAhccMAIX
-					HUACFx4hAhcfAQ==
-					</data>
+					<data>AUccAAFHHUEBRx4XAUcfmQGHHBABhx2QAYcegQGHHwEBtxwgAbcdkQG3HqcBtx+ZAhccMAIXHUACFx4hAhcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2696,11 +2062,7 @@
 					<key>Comment</key>
 					<string>ALC269VC for Lenovo Z580, John</string>
 					<key>ConfigData</key>
-					<data>
-					AVccQAFXHRABVx4hAVcfAwGHHCABhx0QAYce
-					gQGHHwMBlxwwAZcdAQGXHqABlx+QAbccEAG3
-					HQEBtx4XAbcfkAFXDAI=
-					</data>
+					<data>AVccQAFXHRABVx4hAVcfAwGHHCABhx0QAYcegQGHHwMBlxwwAZcdAQGXHqABlx+QAbccEAG3HQEBtx4XAbcfkAFXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2714,11 +2076,7 @@
 					<key>Comment</key>
 					<string>ALC269VC for Lenovo V580, ar4er</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
-					FwFHH5ABVxwwAVcdEAFXHiEBVx8AAYccQAGH
-					HZABhx6BAYcfAgFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABVxwwAVcdEAFXHiEBVx8AAYccQAGHHZABhx6BAYcfAgFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2736,12 +2094,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfkAFHHBABRx0BAUce
-					FwFHH5ABVxyAAVcdEAFXHiEBVx8CAYccIAGH
-					HRABhx6BAYcfAgHnHGAB5x0AAeceQQHnHwIB
-					RwwC
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfkAFHHBABRx0BAUceFwFHH5ABVxyAAVcdEAFXHiEBVx8CAYccIAGHHRABhx6BAYcfAgHnHGAB5x0AAeceQQHnHwIBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2759,11 +2112,7 @@
 					<key>Comment</key>
 					<string>Custom ALC269 Samsung np880z5e-x01ru by Constanta</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfkAG3HCABtx0AAbce
-					FwG3H5ABVxwwAVcdEAFXHiEBVx8AAYccQAGH
-					HZABhx6BAYcfAgG3DAI=
-					</data>
+					<data>ASccEAEnHQABJx6mAScfkAG3HCABtx0AAbceFwG3H5ABVxwwAVcdEAFXHiEBVx8AAYccQAGHHZABhx6BAYcfAgG3DAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2777,11 +2126,7 @@
 					<key>Comment</key>
 					<string>Custom ALC269VC for Samsung NP530U3C-A0F by BblDE3HAP</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQEBRx4XAUcfkAFHDAIBVxxAAVcd
-					EAFXHiEBVx8DAVcMAgGHHCABhx0QAYcegQGH
-					HwMBlxwwAZcdAQGXHqABlx+Q
-					</data>
+					<data>AUccEAFHHQEBRx4XAUcfkAFHDAIBVxxAAVcdEAFXHiEBVx8DAVcMAgGHHCABhx0QAYcegQGHHwMBlxwwAZcdAQGXHqABlx+Q</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2799,11 +2144,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfkAGHHCABhx0QAYce
-					gQGHHwIBVxwwAVcdEAFXHiEBVx8CAZccQAGX
-					HQABlx6gAZcfkAFHDAI=
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfkAGHHCABhx0QAYcegQGHHwIBVxwwAVcdEAFXHiEBVx8CAZccQAGXHQABlx6gAZcfkAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2821,11 +2162,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUce
-					FwFHH5ABRwwCAVccIAFXHRABVx4hAVcfAAGH
-					HDABhx0QAYcegQGHHwA=
-					</data>
+					<data>ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABRwwCAVccIAFXHRABVx4hAVcfAAGHHDABhx0QAYcegQGHHwA=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2845,11 +2182,7 @@
 					<key>Comment</key>
 					<string>Laptop patch ALC269VC Samsung _NP350V5C - Giesteira</string>
 					<key>ConfigData</key>
-					<data>
-					AUccAAFHHQABRx4XAUcfmQGHHBABhx0QAYce
-					gQGHHwEBVxwgAVcdEAFXHiEBVx8BAZccMAGX
-					HQABlx6nAZcfmQFHDAI=
-					</data>
+					<data>AUccAAFHHQABRx4XAUcfmQGHHBABhx0QAYcegQGHHwEBVxwgAVcdEAFXHiEBVx8BAZccMAGXHQABlx6nAZcfmQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2867,11 +2200,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfmQGHHCABhx0QAYce
-					gQGHHwEBJxwwAScdAAEnHqYBJx+ZAhccUAIX
-					HRACFx4hAhcfAQFHDAI=
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfmQGHHCABhx0QAYcegQGHHwEBJxwwAScdAAEnHqYBJx+ZAhccUAIXHRACFx4hAhcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2889,15 +2218,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUce
-					FwFHH5ABRwwCAVccUAFXHRABVx4rAVcfAgFX
-					DAIBdxzwAXcdAAF3HgABdx9AAYccIAGHHRAB
-					hx6LAYcfAgGXHPABlx0AAZceAAGXH0ABpxzw
-					AacdAAGnHgABpx9AAbccYAG3HUABtx4BAbcf
-					AQHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHn
-					HgAB5x9A
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUceFwFHH5ABRwwCAVccUAFXHRABVx4rAVcfAgFXDAIBdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6LAYcfAgGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccYAG3HUABtx4BAbcfAQHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2915,15 +2236,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAGHHDABhx0QAYce
-					gQGHHwABJxxAAScdAAEnHqABJx+QAVccIAFX
-					HRABVx4hAVcfAAF3HPABdx0AAXceAAF3H0AB
-					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
-					AacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcd
-					AAHXHgAB1x9AAeccYAHnHRAB5x5EAecfAgFH
-					DAI=
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAGHHDABhx0QAYcegQGHHwABJxxAAScdAAEnHqABJx+QAVccIAFXHRABVx4hAVcfAAF3HPABdx0AAXceAAF3H0ABlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAeccYAHnHRAB5x5EAecfAgFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2937,14 +2250,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUce
-					FwFHH5ABVxwgAVcdEAFXHiEBVx8CAXcc8AF3
-					HQABdx4AAXcfQAGHHAABhx0QAYcegQGHHwIB
-					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
-					AacfQAG3HPABtx0AAbceAAG3H0AB5xxwAecd
-					EQHnHkQB5x8CAUcMAg==
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUceFwFHH5ABVxwgAVcdEAFXHiEBVx8CAXcc8AF3HQABdx4AAXcfQAGHHAABhx0QAYcegQGHHwIBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB5xxwAecdEQHnHkQB5x8CAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2962,11 +2268,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQEBRx4TAUcfkAGHHCABhx0QAYce
-					gQGHHwEBlxwgAZcdAQGXHqABlx+QAhccEAIX
-					HRACFx4hAhcfAQFHDAI=
-					</data>
+					<data>AUccEAFHHQEBRx4TAUcfkAGHHCABhx0QAYcegQGHHwEBlxwgAZcdAQGXHqABlx+QAhccEAIXHRACFx4hAhcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2984,14 +2286,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUce
-					FwFHH5ABVxwgAVcdEAFXHiEBVx8CAXcc8AF3
-					HQABdx4AAXcfQAGHHAABhx0QAYcegQGHHwIB
-					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
-					AacfQAG3HPABtx0AAbceAAG3H0AB5xzwAecd
-					AAHnHgAB5x9AAUcMAg==
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUceFwFHH5ABVxwgAVcdEAFXHiEBVx8CAXcc8AF3HQABdx4AAXcfQAGHHAABhx0QAYcegQGHHwIBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB5xzwAecdAAHnHgAB5x9AAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3011,15 +2306,7 @@
 					<key>Comment</key>
 					<string>ALC269 Asus K53SJ, Asus G73s Mod by Andrey1970 (No input boost - no noise in Siri)</string>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
-					EwFHH5ABdxxQAXcdAQF3HhMBdx+QAYccIAGH
-					HZABhx6BAYcfAwGXHDABlx0BAZceoAGXH5AB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAwFH
-					DAI=
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceEwFHH5ABdxxQAXcdAQF3HhMBdx+QAYccIAGHHZABhx6BAYcfAwGXHDABlx0BAZceoAGXH5ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAwFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3037,11 +2324,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					EwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIX
-					HRACFx4hAhcfAAFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3061,11 +2344,7 @@
 					<key>Comment</key>
 					<string>ALC269 for GPD P2 Max by DalianSky</string>
 					<key>ConfigData</key>
-					<data>
-					AVccEAFXHRABVx4hAVcfBAGnHCABpx0BAace
-					FwGnH5ABpwwCAYccMAGHHRABhx6BAYcfBAEn
-					HEABJx0BAScepgEnH7c=
-					</data>
+					<data>AVccEAFXHRABVx4hAVcfBAGnHCABpx0BAaceFwGnH5ABpwwCAYccMAGHHRABhx6BAYcfBAEnHEABJx0BAScepgEnH7c=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3085,11 +2364,7 @@
 					<key>Comment</key>
 					<string>Custom ALC269 Acer Aspire by Andrey1970 (No input boost - no noise in Siri)</string>
 					<key>ConfigData</key>
-					<data>
-					AUccAAFHHUEBRx4XAUcfmQGHHBABhx2QAYce
-					gQGHHwEBtxwgAbcdkQG3HqcBtx+ZAhccMAIX
-					HUACFx4hAhcfAQ==
-					</data>
+					<data>AUccAAFHHUEBRx4XAUcfmQGHHBABhx2QAYcegQGHHwEBtxwgAbcdkQG3HqcBtx+ZAhccMAIXHUACFx4hAhcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3105,12 +2380,7 @@
 					<key>Comment</key>
 					<string>ALC269 for Lenovo Y500 by BaoStorm (No input boost - no noise in Siri)</string>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQkBJx6mAScfkAFHHBABRx0BAUce
-					FwFHH5ABRwwCAVccIAFXHSABVx4hAVcfBAFX
-					DAIBhxxQAYcdKAGHHqEBhx8EAeccMAHnHSEB
-					5x5FAecfBA==
-					</data>
+					<data>ASccQAEnHQkBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABRwwCAVccIAFXHSABVx4hAVcfBAFXDAIBhxxQAYcdKAGHHqEBhx8EAeccMAHnHSEB5x5FAecfBA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3124,15 +2394,7 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUce
-					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYccEAGH
-					HRABhx6AAYcfkAGXHBABlx0AAZceoAGXH5AB
-					pxyQAacdAQGnHhcBpx+QAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xxwAecd
-					EQHnHkQB5x8EAhccoAIXHRACFx4hAhcfBAFH
-					DAI=
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYccEAGHHRABhx6AAYcfkAGXHBABlx0AAZceoAGXH5ABpxyQAacdAQGnHhcBpx+QAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xxwAecdEQHnHkQB5x8EAhccoAIXHRACFx4hAhcfBAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3146,10 +2408,7 @@
 					<key>CodecID</key>
 					<integer>283902576</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAGXHCABlx0AAZce
-					oAGXH5ACFxwwAhcdEAIXHiECFx8AAUcMAg==
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAGXHCABlx0AAZceoAGXH5ACFxwwAhcdEAIXHiECFx8AAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3167,10 +2426,7 @@
 					<key>CodecID</key>
 					<integer>283902576</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					EwFHH5ACFxwwAhcdEAIXHiECFx8BAUcMAg==
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ACFxwwAhcdEAIXHiECFx8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3190,15 +2446,7 @@
 					<key>Comment</key>
 					<string>ALC270 for Asus A46CB-WX024D Laptop by Andres ZeroCross</string>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGH
-					HRABhx6BAYcfBAGXHDABlx0BAZceoAGXH5AB
-					pxwgAacdEAGnHiEBpx8EAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhcc8AIXHQACFx4AAhcfQAFH
-					DAI=
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfBAGXHDABlx0BAZceoAGXH5ABpxwgAacdEAGnHiEBpx8EAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhcc8AIXHQACFx4AAhcfQAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3218,15 +2466,7 @@
 					<key>Comment</key>
 					<string>ALC270 for Asus Laptop with alternative microphone</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHCABRx0BAUce
-					EwFHH5ABdxzwAXcdAAF3HgABdx9AAYccMAGH
-					HRABhx6BAYcfAgGXHPABlx0AAZceAAGXH0AB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAgFH
-					DAI=
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHCABRx0BAUceEwFHH5ABdxzwAXcdAAF3HgABdx9AAYccMAGHHRABhx6BAYcfAgGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAgFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3246,15 +2486,7 @@
 					<key>Comment</key>
 					<string>ALC270 for Asus Laptop</string>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGH
-					HRABhx6BAYcfBAGXHDABlx0BAZceoAGXH5AB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccIAIXHRACFx4hAhcfBAFH
-					DAI=
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfBAGXHDABlx0BAZceoAGXH5ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccIAIXHRACFx4hAhcfBAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3272,12 +2504,7 @@
 					<key>Comment</key>
 					<string>Custom ALC271x Acer Aspire s3-951</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					EwFHH5ABhxwwAYcdkAGHHoEBhx8AAdccQAHX
-					HZAB1x4XAdcfQAHnHFAB5x0QAeceRQHnHwAC
-					FxxgAhcdEAIXHiECFx8AAUcMAg==
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ABhxwwAYcdkAGHHoEBhx8AAdccQAHXHZAB1x4XAdcfQAHnHFAB5x0QAeceRQHnHwACFxxgAhcdEAIXHiECFx8AAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3295,11 +2522,7 @@
 					<key>CodecID</key>
 					<integer>283902578</integer>
 					<key>ConfigData</key>
-					<data>
-					AYccMAGHHZABhx6BAYcfAAGXHCABlx0AAZce
-					owGXH5ABRxwQAUcdAAFHHhMBRx+QAhccUAIX
-					HUACFx4hAhcfAAFHDAI=
-					</data>
+					<data>AYccMAGHHZABhx6BAYcfAAGXHCABlx0AAZceowGXH5ABRxwQAUcdAAFHHhMBRx+QAhccUAIXHUACFx4hAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3317,11 +2540,7 @@
 					<key>CodecID</key>
 					<integer>283902578</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6jAScfkAFHHBABRx0AAUce
-					EwFHH5ABhxwgAYcdEAGHHoEBhx8AAhccUAIX
-					HRACFx4hAhcfAAFHDAI=
-					</data>
+					<data>ASccMAEnHQABJx6jAScfkAFHHBABRx0AAUceEwFHH5ABhxwgAYcdEAGHHoEBhx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3339,11 +2558,7 @@
 					<key>CodecID</key>
 					<integer>283902578</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUce
-					EwFHH5ABRwwCAYccMAGHHZABhx6BAYcfAQIX
-					HEACFx1AAhceIQIXHwE=
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUceEwFHH5ABRwwCAYccMAGHHZABhx6BAYcfAQIXHEACFx1AAhceIQIXHwE=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3357,11 +2572,7 @@
 					<key>CodecID</key>
 					<integer>283902578</integer>
 					<key>ConfigData</key>
-					<data>
-					AYccQAGHHZABhx6BAYcfAQEnHDABJx0BASce
-					oAEnH5ABpxwQAacdAQGnHhMBpx+ZAhccIAIX
-					HRACFx4hAhcfAQ==
-					</data>
+					<data>AYccQAGHHZABhx6BAYcfAQEnHDABJx0BASceoAEnH5ABpxwQAacdAQGnHhMBpx+ZAhccIAIXHRACFx4hAhcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3375,11 +2586,7 @@
 					<key>CodecID</key>
 					<integer>283902580</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6gAScfkAFnHBABZx0BAWce
-					FwFnH5ABlxxAAZcdAAGXHoEBlx8EAhccIAIX
-					HRACFx4hAhcfBAFHDAICFwwC
-					</data>
+					<data>ASccMAEnHQEBJx6gAScfkAFnHBABZx0BAWceFwFnH5ABlxxAAZcdAAGXHoEBlx8EAhccIAIXHRACFx4hAhcfBAFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3397,10 +2604,7 @@
 					<key>CodecID</key>
 					<integer>283902581</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccAAEnHQABJx6gAScfkAFHHBABRx0BAUce
-					FwFHH5ABVxwgAVcdEAFXHiEBVx8DAUcMAg==
-					</data>
+					<data>ASccAAEnHQABJx6gAScfkAFHHBABRx0BAUceFwFHH5ABVxwgAVcdEAFXHiEBVx8DAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3418,12 +2622,7 @@
 					<key>CodecID</key>
 					<integer>283902581</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQEBRx4XAUcfkAFXHCABVx0QAVce
-					IQFXHwMBJxwwAScdAAEnHqABJx+QAYccQAGH
-					HVABhx6BAYcfAAHnHFAB5x0QAeceRQHnHwAB
-					RwwC
-					</data>
+					<data>AUccEAFHHQEBRx4XAUcfkAFXHCABVx0QAVceIQFXHwMBJxwwAScdAAEnHqABJx+QAYccQAGHHVABhx6BAYcfAAHnHFAB5x0QAeceRQHnHwABRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3441,11 +2640,7 @@
 					<key>CodecID</key>
 					<integer>283902581</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQABJx6gAScfkAFXHBABVx0QAVce
-					IQFXHwABhxwwAYcdUAGHHoEBhx8AAaccUAGn
-					HQABpx4XAacfkAGnDAI=
-					</data>
+					<data>ASccQAEnHQABJx6gAScfkAFXHBABVx0QAVceIQFXHwABhxwwAYcdUAGHHoEBhx8AAaccUAGnHQABpx4XAacfkAGnDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3459,11 +2654,7 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAFXHCABVx0QAVce
-					IQFXHwEBJxwwAScdAAEnHqABJx+QAaccQAGn
-					HRABpx6BAacfAgFHDAIBVwwC
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAFXHCABVx0QAVceIQFXHwEBJxwwAScdAAEnHqABJx+QAaccQAGnHRABpx6BAacfAgFHDAIBVwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3481,11 +2672,7 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					FwFHH5ABVxwwAVcdEAFXHiEBVx8CAaccQAGn
-					HRABpx6BAacfAgFHDAIBVwwC
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABVxwwAVcdEAFXHiEBVx8CAaccQAGnHRABpx6BAacfAgFHDAIBVwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3503,14 +2690,7 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>
-					IUcc8CFHHQAhRx4AIUcfQCFXHPAhVx0AIVce
-					ACFXH0AhZxzwIWcdACFnHgAhZx9AIXcc8CF3
-					HQAhdx4AIXcfQCGHHPAhhx0AIYceACGHH0Ah
-					lxzwIZcdACGXHgAhlx9AIacc8CGnHQAhpx4A
-					IacfQCG3HPAhtx0AIbceACG3H0Ah5xwQIecd
-					4SHnHkUh5x8B
-					</data>
+					<data>IUcc8CFHHQAhRx4AIUcfQCFXHPAhVx0AIVceACFXH0AhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHPAhhx0AIYceACGHH0AhlxzwIZcdACGXHgAhlx9AIacc8CGnHQAhpx4AIacfQCG3HPAhtx0AIbceACG3H0Ah5xwQIecd4SHnHkUh5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3524,11 +2704,7 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccIAG3HUABtx4BAbcfAQGnHDABpx2QAace
-					gQGnHwIBhxxAAYcdMAGHHoEBhx8BAVccYAFX
-					HUABVx4hAVcfAgFXDAI=
-					</data>
+					<data>AbccIAG3HUABtx4BAbcfAQGnHDABpx2QAacegQGnHwIBhxxAAYcdMAGHHoEBhx8BAVccYAFXHUABVx4hAVcfAgFXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3542,11 +2718,7 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccIAG3HUABtx4RAbcfkAGnHDABpx2QAace
-					gQGnHwIBhxxAAYcdMAGHHoEBhx8BAVccYAFX
-					HUABVx4hAVcfAgFXDAI=
-					</data>
+					<data>AbccIAG3HUABtx4RAbcfkAGnHDABpx2QAacegQGnHwIBhxxAAYcdMAGHHoEBhx8BAVccYAFXHUABVx4hAVcfAgFXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3560,11 +2732,7 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>
-					AaccMAGnHZABpx6BAacfAgGHHEABhx0wAYce
-					gQGHHwEBRxxQAUcdAAFHHhcBRx+QAUcMAgFX
-					HGABVx1AAVceIQFXHwIBVwwC
-					</data>
+					<data>AaccMAGnHZABpx6BAacfAgGHHEABhx0wAYcegQGHHwEBRxxQAUcdAAFHHhcBRx+QAUcMAgFXHGABVx1AAVceIQFXHwIBVwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3582,11 +2750,7 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>
-					AVccIAFXHUABVx4hAVcfAgGHHDABhx0AAYce
-					oAGHH5ABpxxAAacdkAGnHoEBpx8CAbccEAG3
-					HQABtx4AAbcfAQFnDAI=
-					</data>
+					<data>AVccIAFXHUABVx4hAVcfAgGHHDABhx0AAYceoAGHH5ABpxxAAacdkAGnHoEBpx8CAbccEAG3HQABtx4AAbcfAQFnDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3600,11 +2764,7 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfmQFHHCABRx0AAUce
-					EwGXHDABlx0QAZceiwGXHwABRx+ZAhccUAIX
-					HRACFx4rAhcfAQFHDAICFwwC
-					</data>
+					<data>ASccEAEnHQABJx6gAScfmQFHHCABRx0AAUceEwGXHDABlx0QAZceiwGXHwABRx+ZAhccUAIXHRACFx4rAhcfAQFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3622,12 +2782,7 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUce
-					FwFHH5ABhxwwAYcdEAGHHoEBhx8AAeccIAHn
-					HRAB5x5EAecfAAIXHFACFx0QAhceIQIXHwAB
-					RwwC
-					</data>
+					<data>ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABhxwwAYcdEAGHHoEBhx8AAeccIAHnHRAB5x5EAecfAAIXHFACFx0QAhceIQIXHwABRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3645,12 +2800,7 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUce
-					FwFHH5ABhxwwAYcdEAGHHoEBhx8AAeccIAHn
-					HRAB5x5EAecfAAIXHFACFx0QAhceIQIXHwAB
-					RwwC
-					</data>
+					<data>ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABhxwwAYcdEAGHHoEBhx8AAeccIAHnHRAB5x5EAecfAAIXHFACFx0QAhceIQIXHwABRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3668,15 +2818,7 @@
 					<key>Comment</key>
 					<string>Custom ALC282 lenovo y430p by loverto</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUcd
-					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYcccAGH
-					HRABhx6BAYcfAQGHHAIBlxzwAZcdAAGXHgAB
-					lx9AAacc8AGnHQABpx4AAacfQAG3HEABtx0B
-					AbceFwG3H5AB1xzwAdcdAAHXHgAB1x9AAecc
-					YAHnHRAB5x5EAecfAQIXHFACFx0QAhceIQIX
-					HwECFxwC
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUcdAAFHH0ABdxzwAXcdAAF3HgABdx9AAYcccAGHHRABhx6BAYcfAQGHHAIBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HEABtx0BAbceFwG3H5AB1xzwAdcdAAHXHgAB1x9AAeccYAHnHRAB5x5EAecfAQIXHFACFx0QAhceIQIXHwECFxwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3694,14 +2836,7 @@
 					<key>Comment</key>
 					<string>Skvo ALC282 Acer Aspire on IvyBridge by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcd
-					EAIXHiECFx8B
-					</data>
+					<data>ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIXHiECFx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3715,14 +2850,7 @@
 					<key>Comment</key>
 					<string>Custom ALC282 Acer Aspire E1-572G</string>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHBABRx0AAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
-					pxzwAacdAAGnHgABpx9AAbccMAG3HQEBtx6g
-					AbcfkAHnHPAB5x0AAeceAAHnH0ACFxwgAhcd
-					EAIXHiECFx8B
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0AAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccMAG3HQEBtx6gAbcfkAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIXHiECFx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3736,11 +2864,7 @@
 					<key>Comment</key>
 					<string>Custom ALC282 Dell Inspirion 3521 by Generation88</string>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQEBJx6gAScfkAFHHBABRx0BAUce
-					FwFHH5ABlxwwAZcdEAGXHoEBlx8BAhccIAIX
-					HRACFx4hAhcfAQFHDAI=
-					</data>
+					<data>ASccQAEnHQEBJx6gAScfkAFHHBABRx0BAUceFwFHH5ABlxwwAZcdEAGXHoEBlx8BAhccIAIXHRACFx4hAhcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3758,15 +2882,7 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUce
-					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYccIAGH
-					HRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0AB
-					pxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4X
-					AbcfkAHXHPAB1x0AAdceAAHXH0AB5xxwAecd
-					EAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFH
-					DAI=
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4XAbcfkAHXHPAB1x0AAdceAAHXH0AB5xxwAecdEAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3784,15 +2900,7 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUce
-					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYccIAGH
-					HRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0AB
-					pxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4X
-					AbcfkAHXHPAB1x0AAdceAAHXH0AB5xxwAecd
-					EAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFH
-					DAI=
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4XAbcfkAHXHPAB1x0AAdceAAHXH0AB5xxwAecdEAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3810,15 +2918,7 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGH
-					HRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0AB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xxwAecd
-					EAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFH
-					DAI=
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xxwAecdEAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3836,15 +2936,7 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHCABRx1AAUce
-					EQFHHwEBdxzwAXcdAAF3HgABdx9AAYccIAGH
-					HRABhx6BAYcfAQGXHPABlx0AAZceAQGXH0AB
-					pxzwAacdAAGnHgEBpx9AAdcc8AG3HQABtx4B
-					AbcfQAHXHPUB1x0AAdceBQHXH0AB5xzwAecd
-					AAHnHgEB5x9AAhccQAIXHXACFx4hAhcfAQFH
-					DAI=
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHCABRx1AAUceEQFHHwEBdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfAQGXHPABlx0AAZceAQGXH0ABpxzwAacdAAGnHgEBpx9AAdcc8AG3HQABtx4BAbcfQAHXHPUB1x0AAdceBQHXH0AB5xzwAecdAAHnHgEB5x9AAhccQAIXHXACFx4hAhcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3862,15 +2954,7 @@
 					<key>Comment</key>
 					<string>Custom ALC282 for Asus x200la</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6BAScfAAFHHCABRx0BAUce
-					EAFHH5kBdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHDABlx0BAZcepgGXH5kB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccUAIXHUACFx4rAhcfAAFH
-					DAICFwwC
-					</data>
+					<data>ASccEAEnHQABJx6BAScfAAFHHCABRx0BAUceEAFHH5kBdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHDABlx0BAZcepgGXH5kBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccUAIXHUACFx4rAhcfAAFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3888,14 +2972,7 @@
 					<key>Comment</key>
 					<string>No input boost ALC282 Acer Aspire on IvyBridge by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcd
-					EAIXHiECFx8B
-					</data>
+					<data>ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIXHiECFx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3909,15 +2986,7 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUce
-					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHGABlx0wAZceiwGXHwEB
-					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhcccAIXHUACFx4rAhcfAQGX
-					DAICFwwC
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHGABlx0wAZceiwGXHwEBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhcccAIXHUACFx4rAhcfAQGXDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3931,11 +3000,7 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUce
-					FwFHH5ABlxwwAZcdAAGXHosBlx8AAhccQAIX
-					HRACFx4rAhcfAQFHDAICFwwC
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUceFwFHH5ABlxwwAZcdAAGXHosBlx8AAhccQAIXHRACFx4rAhcfAQFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3953,15 +3018,7 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUce
-					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
-					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
-					pxzwAacdAAGnHgABpx8AAbcc8AG3HQABtx4A
-					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAhccUAIXHRACFx4hAhcfAwFH
-					DAICFwwC
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx8AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccUAIXHRACFx4hAhcfAwFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3979,11 +3036,7 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfkAFHDAIBlxwgAZcd
-					EAGXHoEBlx8AASccMAEnHQABJx6mAScfkAIX
-					HGACFx0QAhceIQIXHwACFwwC
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfkAFHDAIBlxwgAZcdEAGXHoEBlx8AASccMAEnHQABJx6mAScfkAIXHGACFx0QAhceIQIXHwACFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4001,12 +3054,7 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccQAG3HQABtx4XAbcfmQEnHBABJx0AASce
-					pgEnH5kBlxwgAZcdkAGXHoEBlx8BAaccMAGn
-					HZABpx6BAacfAQIXHAACFx1AAhceIQIXHwEB
-					RwwC
-					</data>
+					<data>AbccQAG3HQABtx4XAbcfmQEnHBABJx0AAScepgEnH5kBlxwgAZcdkAGXHoEBlx8BAaccMAGnHZABpx6BAacfAQIXHAACFx1AAhceIQIXHwEBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4024,12 +3072,7 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccgAEnHQABJx4AAScfQAFHHEABRx0BAUce
-					EwFHH5ABpxwgAacdkAGnHoEBpx8BAdccYAHX
-					HZAB1x5VAdcfQAIXHFACFx0QAhceIQIXHwEB
-					RwwCAhcMAg==
-					</data>
+					<data>ASccgAEnHQABJx4AAScfQAFHHEABRx0BAUceEwFHH5ABpxwgAacdkAGnHoEBpx8BAdccYAHXHZAB1x5VAdcfQAIXHFACFx0QAhceIQIXHwEBRwwCAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4047,12 +3090,7 @@
 					<key>CodecID</key>
 					<integer>283902596</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAE3HCABNx0AATce
-					AAE3H0ABRxwwAUcdAAFHHhcBRx+QAVccQAFX
-					HRABVx4hAVcfAAGHHFABhx0QAYcegQGHHwIB
-					1xxgAdcdgAHXHmYB1x9AAUcMAg==
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAE3HCABNx0AATceAAE3H0ABRxwwAUcdAAFHHhcBRx+QAVccQAFXHRABVx4hAVcfAAGHHFABhx0QAYcegQGHHwIB1xxgAdcdgAHXHmYB1x9AAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4070,12 +3108,7 @@
 					<key>CodecID</key>
 					<integer>283902597</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUce
-					FwFHH5ABlxwAAZcdEAGXHosBlx8BAhccIAIX
-					HRACFx4rAhcfAQHXHGAB1x2AAdceZgHXH0AB
-					RwwC
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUceFwFHH5ABlxwAAZcdEAGXHosBlx8BAhccIAIXHRACFx4rAhcfAQHXHGAB1x2AAdceZgHXH0ABRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4093,11 +3126,7 @@
 					<key>CodecName</key>
 					<string>Andres - Realtek ALC285 for  Lenovo X1 Carbon 6th </string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUce
-					FwFHH5ABlxwAAZcdEAGXHosBlx8EAhccIAIX
-					HRACFx4rAhcfBAFHDAI=
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUceFwFHH5ABlxwAAZcdEAGXHosBlx8EAhccIAIXHRACFx4rAhcfBAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4115,15 +3144,7 @@
 					<key>CodecName</key>
 					<string>Flymin - Realtek ALC285 for  Thinkpad X1E</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFn
-					HPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgAB
-					dx9AAYcc8AGHHQABhx4AAYcfQAGXHCABlx0Q
-					AZceiwGXHwQBpxzwAacdAAGnHgABpx9AAdcc
-					8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHn
-					H0ACFxxQAhcdEAIXHisCFx8EAhcMAg==
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFnHPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHCABlx0QAZceiwGXHwQBpxzwAacdAAGnHgABpx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIXHisCFx8EAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4141,11 +3162,7 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC286</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfsAFHHCABRx0AAUce
-					FwFHH5ABhxwwAYcdEAGHHosBhx8EAhccQAIX
-					HRACFx4rAhcfBAFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6mAScfsAFHHCABRx0AAUceFwFHH5ABhxwwAYcdEAGHHosBhx8EAhccQAIXHRACFx4rAhcfBAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4163,15 +3180,7 @@
 					<key>CodecName</key>
 					<string>Lenovo YOGA3 pro ALC286 - gdllzkusi</string>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgF3
-					HPABdx0AAXceAAF3H0ABhxwQAYcdEAGHHoEB
-					hx8EAZcc8AGXHQABlx4AAZcfQAGnHPABpx0A
-					AaceAAGnH0AB1xzwAdcdAAHXHgAB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHDACFx0QAhceIQIX
-					HwQCFwwC
-					</data>
+					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgF3HPABdx0AAXceAAF3H0ABhxwQAYcdEAGHHoEBhx8EAZcc8AGXHQABlx4AAZcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHDACFx0QAhceIQIXHwQCFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4189,12 +3198,7 @@
 					<key>CodecID</key>
 					<integer>283902600</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAE3HCABNx0AATce
-					AAE3H0ABRxwwAUcdAAFHHhcBRx+QAYccQAGH
-					HRABhx6BAYcfAgHXHFAB1x2AAdceZQHXH0AC
-					FxxgAhcdEAIXHiECFx8BAUcMAg==
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAE3HCABNx0AATceAAE3H0ABRxwwAUcdAAFHHhcBRx+QAYccQAGHHRABhx6BAYcfAgHXHFAB1x2AAdceZQHXH0ACFxxgAhcdEAIXHiECFx8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4212,11 +3216,7 @@
 					<key>CodecID</key>
 					<integer>283902600</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQABJx6gAScfkAFHHDABRx0AAUce
-					FwFHH5ABNxxAATcdEAE3HoEBNx8AAhccUAIX
-					HRACFx4hAhcfAAFHDAI=
-					</data>
+					<data>ASccIAEnHQABJx6gAScfkAFHHDABRx0AAUceFwFHH5ABNxxAATcdEAE3HoEBNx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4234,15 +3234,7 @@
 					<key>CodecID</key>
 					<integer>283902600</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgF3
-					HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgAB
-					hx9AAZcc8AGXHQABlx4AAZcfQAGnHHABpx0g
-					AacYqwGnHwIBpwwCAdcc8AHXHQAB1x4AAdcf
-					QAHnHPAB5x0AAeceAAHnH0ACFxw/AhcdEAIX
-					HisCFx8D
-					</data>
+					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4AAZcfQAGnHHABpx0gAacYqwGnHwIBpwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxw/AhcdEAIXHisCFx8D</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4260,11 +3252,7 @@
 					<key>CodecID</key>
 					<integer>283902601</integer>
 					<key>ConfigData</key>
-					<data>
-					ATccMAE3HQEBNx6mATcftwFHHBABRx0BAUce
-					FwFHH5ABRwwCAbccQAG3HRABtx6BAbcfAwG3
-					DAICFxwgAhcdEAIXHiECFx8DAhcMAg==
-					</data>
+					<data>ATccMAE3HQEBNx6mATcftwFHHBABRx0BAUceFwFHH5ABRwwCAbccQAG3HRABtx6BAbcfAwG3DAICFxwgAhcdEAIXHiECFx8DAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4282,11 +3270,7 @@
 					<key>CodecID</key>
 					<integer>283902608</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfkAFXHCABVx0QAVce
-					KwFXHwIBlxwwAZcdAAGXHqABlx+QAaccQAGn
-					HRABpx6LAacfAAFHDAI=
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfkAFXHCABVx0QAVceKwFXHwIBlxwwAZcdAAGXHqABlx+QAaccQAGnHRABpx6LAacfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4304,11 +3288,7 @@
 					<key>Comment</key>
 					<string>macpeetALC ALC290 aka ALC3241</string>
 					<key>ConfigData</key>
-					<data>
-					AaccIAGnHRABpx6BAacfAAEnHDABJx0AASce
-					owEnH5ABRxxAAUcdAAFHHhcBRx+QAVccUAFX
-					HRABVx4hAVcfAAFHDAI=
-					</data>
+					<data>AaccIAGnHRABpx6BAacfAAEnHDABJx0AASceowEnH5ABRxxAAUcdAAFHHhcBRx+QAVccUAFXHRABVx4hAVcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4326,11 +3306,7 @@
 					<key>Comment</key>
 					<string>vusun123 - ALC 290 for Dell Vostro 5480</string>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUce
-					FwFHH5ABRwwCAVccIAFXHRABVx4hAVcfAAGn
-					HEABpx0QAacegQGnHwA=
-					</data>
+					<data>ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABRwwCAVccIAFXHRABVx4hAVcfAAGnHEABpx0QAacegQGnHwA=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4348,11 +3324,7 @@
 					<key>CodecID</key>
 					<integer>283902610</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfmQFHHCABRx0AAUce
-					FwFHH5kBVxwwAVcdQAFXHiEBVx8BAZccUAGX
-					HZABlx6BAZcfAQFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6gAScfmQFHHCABRx0AAUceFwFHH5kBVxwwAVcdQAFXHiEBVx8BAZccUAGXHZABlx6BAZcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4370,11 +3342,7 @@
 					<key>CodecID</key>
 					<integer>283902610</integer>
 					<key>ConfigData</key>
-					<data>
-					AaccIAGnHRABpx6BAacfAAEnHDABJx0AASce
-					pgEnH5ABRxxAAUcdAAFHHhcBRx+QAUcMAgFX
-					HFABVx0QAVceAQFXHwABVwwC
-					</data>
+					<data>AaccIAGnHRABpx6BAacfAAEnHDABJx0AAScepgEnH5ABRxxAAUcdAAFHHhcBRx+QAUcMAgFXHFABVx0QAVceAQFXHwABVwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4392,11 +3360,7 @@
 					<key>Comment</key>
 					<string>vanquybn - ALC 292 for Dell M4800</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfkAGHHCABhx2QAYce
-					gQGHHwEBJxwwAScdAAEnHqYBJx+QAVccQAFX
-					HUABVx4hAVcfAQ==
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfkAGHHCABhx2QAYcegQGHHwEBJxwwAScdAAEnHqYBJx+QAVccQAFXHUABVx4hAVcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4410,11 +3374,7 @@
 					<key>Comment</key>
 					<string>vusun123 - ALC 292 for Lenovo T440</string>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6gAScfkAFHHEABRx0AAUce
-					FwFHH5ABRwwCAVccUAFXHRABVx4hAVcfAAGn
-					HCABpx0QAacegQGnHwA=
-					</data>
+					<data>ASccMAEnHQABJx6gAScfkAFHHEABRx0AAUceFwFHH5ABRwwCAVccUAFXHRABVx4hAVcfAAGnHCABpx0QAacegQGnHwA=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4432,15 +3392,7 @@
 					<key>Comment</key>
 					<string>ALC292 for Lenovo T450s By Echo</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRx0BAUceFwFHH5ABRwwCAVccQAFX
-					HRABVx4rAVcfBAFXDAIBZxzwAWcdAAFnHgAB
-					Zx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0A
-					AZceAAGXH0ABpxwgAacdEAGnHosBpx8EAbcc
-					8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHX
-					H0AB5xzwAecdAAHnHgAB5x9AAUccMA==
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRx0BAUceFwFHH5ABRwwCAVccQAFXHRABVx4rAVcfBAFXDAIBZxzwAWcdAAFnHgABZx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxwgAacdEAGnHosBpx8EAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAUccMA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4454,15 +3406,7 @@
 					<key>Comment</key>
 					<string>baesar0 -ALC 292 for e6540 with dock</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFX
-					HFABVx1AAVceKwFXHwIBVwwCAWccgAFnHUAB
-					Zx4BAWcfAgFnDAIBhxzwAYcdAAGHHgABhx9A
-					AZccIAGXHZABlx6BAZcfAgGnHHABpx0QAace
-					qwGnHwIBtxzwAbcdAAG3HgABtx9AAdcc8AHX
-					HQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0A=
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFXHFABVx1AAVceKwFXHwIBVwwCAWccgAFnHUABZx4BAWcfAgFnDAIBhxzwAYcdAAGHHgABhx9AAZccIAGXHZABlx6BAZcfAgGnHHABpx0QAaceqwGnHwIBtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4480,15 +3424,7 @@
 					<key>CodecID</key>
 					<integer>283902611</integer>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAE3HBABNx0BATce
-					oAE3H5ABRxwwAUcdAQFHHhcBRx+QAVccQAFX
-					HUABVx4rAVcfAgFnHFABZx1AAWceAQFnHwIB
-					hxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4A
-					AZcfQAGnHCABpx0QAaceiwGnHwIBtxzwAbcd
-					AAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHn
-					HPAB5x0AAeceAAHnH0ABRwwCAVcMAgFnDAI=
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAE3HBABNx0BATceoAE3H5ABRxwwAUcdAQFHHhcBRx+QAVccQAFXHUABVx4rAVcfAgFnHFABZx1AAWceAQFnHwIBhxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4AAZcfQAGnHCABpx0QAaceiwGnHwIBtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ABRwwCAVcMAgFnDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4506,15 +3442,7 @@
 					<key>CodecID</key>
 					<integer>283902611</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwgAUcdAQFHHhcBRx+QAVccMAFX
-					HRABVx4hAVcfAwFnHPABZx0AAWceAAFnH0AB
-					hxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4A
-					AZcfQAGnHEABpx0QAacegQGnHwMBtxzwAbcd
-					AAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHn
-					HPAB5x0AAeceAAHnH0ABRwwCAVcMAg==
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwgAUcdAQFHHhcBRx+QAVccMAFXHRABVx4hAVcfAwFnHPABZx0AAWceAAFnH0ABhxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4AAZcfQAGnHEABpx0QAacegQGnHwMBtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ABRwwCAVcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4532,15 +3460,7 @@
 					<key>CodecID</key>
 					<integer>283902611</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwgAUcdAQFHHhcBRx+QAVccMAFX
-					HRABVx4hAVcfAwFnHPABZx0AAWceAAFnH0AB
-					hxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4A
-					AZcfQAGnHEABpx0QAacegQGnHwMBtxzwAbcd
-					AAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHn
-					HPAB5x0AAeceAAHnH0ABRwwCAVcMAg==
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwgAUcdAQFHHhcBRx+QAVccMAFXHRABVx4hAVcfAwFnHPABZx0AAWceAAFnH0ABhxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4AAZcfQAGnHEABpx0QAacegQGnHwMBtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ABRwwCAVcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4558,11 +3478,7 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccEAG3HQEBtx6nAbcfkAFHHCABRx0BAUce
-					FwFHH5ACFxwwAhcdEAIXHiECFx8BAUcMAgG3
-					DAICFwwC
-					</data>
+					<data>AbccEAG3HQEBtx6nAbcfkAFHHCABRx0BAUceFwFHH5ACFxwwAhcdEAIXHiECFx8BAUcMAgG3DAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4576,11 +3492,7 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>
-					AhccIAIXHRACFx4hAhcfAAGXHDABlx0QAZce
-					gQGXHwABpxxAAacdkAGnHoEBpx8AAUccUAFH
-					HQABRx4XAUcfkAFHDAI=
-					</data>
+					<data>AhccIAIXHRACFx4hAhcfAAGXHDABlx0QAZcegQGXHwABpxxAAacdkAGnHoEBpx8AAUccUAFHHQABRx4XAUcfkAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4594,10 +3506,7 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASce
-					oAEnH5ACFxwwAhcdEAIXHiECFx8A
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASceoAEnH5ACFxwwAhcdEAIXHiECFx8A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4611,11 +3520,7 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQEBJx6gAScfkAF3HBABdx0BAXce
-					FwF3H5ABlxxAAZcdEAGXHoEBlx8EAhccMAIX
-					HRACFx4hAhcfBAF3DAICFwwC
-					</data>
+					<data>ASccIAEnHQEBJx6gAScfkAF3HBABdx0BAXceFwF3H5ABlxxAAZcdEAGXHoEBlx8EAhccMAIXHRACFx4hAhcfBAF3DAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4633,12 +3538,7 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>
-					ATccAAE3HQABNx4QATcfQAFHHBABRx0BAUce
-					FwFHH5ABRwwCAZccIAGXHRABlx6BAZcfBAIX
-					HDACFx0QAhceIQIXHwQCFwwCAdccQAHXHZoB
-					1x5nAdcfQAEnHFABJx0BASceoAEnH5A=
-					</data>
+					<data>ATccAAE3HQABNx4QATcfQAFHHBABRx0BAUceFwFHH5ABRwwCAZccIAGXHRABlx6BAZcfBAIXHDACFx0QAhceIQIXHwQCFwwCAdccQAHXHZoB1x5nAdcfQAEnHFABJx0BASceoAEnH5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4656,11 +3556,7 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>
-					AhccIAIXHRACFx4hAhcfAQG3HDABtx0BAbce
-					pwG3H5ABlxwwAZcdEAGXHoEBlx8BAUccEAFH
-					HQEBRx4XAUcfkAFHDAIBtwwCAhcMAg==
-					</data>
+					<data>AhccIAIXHRACFx4hAhcfAQG3HDABtx0BAbcepwG3H5ABlxwwAZcdEAGXHoEBlx8BAUccEAFHHQEBRx4XAUcfkAFHDAIBtwwCAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4678,16 +3574,7 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxzwAUcdAAFHHgABRx9AAUcMAgFn
-					HPABZx0AAWceAAFnH0ABdxwQAXcdAQF3HhcB
-					dx+QAYcc8AGHHQABhx4BAYcfQAGXHEABlx0Q
-					AZcegQGXHwIBpxzwAacdAAGnHgABpx9AAbcc
-					8AG3HQABtx4AAbcfQAG3DAIB1xzwAdcdAAHX
-					HgAB1x9AAecc8AHnHQAB5x4BAecfQAIXHCAC
-					Fx0QAhceIQIXHwICFwwC
-					</data>
+					<data>ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAUcMAgFnHPABZx0AAWceAAFnH0ABdxwQAXcdAQF3HhcBdx+QAYcc8AGHHQABhx4BAYcfQAGXHEABlx0QAZcegQGXHwIBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAG3DAIB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4BAecfQAIXHCACFx0QAhceIQIXHwICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4705,11 +3592,7 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6mAScfmQF3HCABdx0AAXce
-					FwF3H5kBlxwwAZcdEAGXHoEBlx8CAhccQAIX
-					HRACFx4hAhcfAgF3DAIBRwwCAhcMAg==
-					</data>
+					<data>ASccEAEnHQABJx6mAScfmQF3HCABdx0AAXceFwF3H5kBlxwwAZcdEAGXHoEBlx8CAhccQAIXHRACFx4hAhcfAgF3DAIBRwwCAhcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4727,16 +3610,7 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFn
-					HPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgAB
-					dx9AAYcc8AGHHQABhx4AAYcfQAGXHBABlx0Q
-					AZcegQGXHwIBpxzwAacdAAGnHgABpx9AAbcc
-					8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHX
-					H0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRAC
-					Fx4hAhcfAgIXDAI=
-					</data>
+					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFnHPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHBABlx0QAZcegQGXHwIBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRACFx4hAhcfAgIXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4754,11 +3628,7 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASce
-					oAEnH5ACFxwwAhcdEAIXHiECFx8AAZccQAGX
-					HRABlx6BAZcfAAIXDAI=
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASceoAEnH5ACFxwwAhcdEAIXHiECFx8AAZccQAGXHRABlx6BAZcfAAIXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4772,11 +3642,7 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4XAUcfkAEnHCABJx0AASce
-					oAEnH5ACFxwwAhcdEAIXHiECFx8AAZccQAGX
-					HRABlx6BAZcfAA==
-					</data>
+					<data>AUccEAFHHQABRx4XAUcfkAEnHCABJx0AASceoAEnH5ACFxwwAhcdEAIXHiECFx8AAZccQAGXHRABlx6BAZcfAA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4790,16 +3656,7 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccIAEnHQEBJx6gAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAWcc8AFn
-					HQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0AB
-					hxzwAYcdAAGHHgABhx9AAZccMAGXHRABlx6B
-					AZcfAgGnHPABpx0AAaceAAGnH0ABtxzwAbcd
-					AAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHn
-					HPAB5x0AAeceAAHnH0ACFxxAAhcdEAIXHiEC
-					Fx8CAUcMAgIXDAI=
-					</data>
+					<data>ASccIAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAZccMAGXHRABlx6BAZcfAgGnHPABpx0AAaceAAGnH0ABtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxxAAhcdEAIXHiECFx8CAUcMAgIXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4813,11 +3670,7 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6gAScfuQFHHFABRx0AAUce
-					FwFHH5ABRwwCAZccQAGXHRABlx6BAZcfAAIX
-					HCACFx0QAhceIQIXHwA=
-					</data>
+					<data>ASccMAEnHQABJx6gAScfuQFHHFABRx0AAUceFwFHH5ABRwwCAZccQAGXHRABlx6BAZcfAAIXHCACFx0QAhceIQIXHwA=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4835,16 +3688,7 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6mAScftwE3HPABNx0AATce
-					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgFn
-					HPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgAB
-					dx9AAYcc8AGHHQABhx4AAYcfQAGXHHABlx0g
-					AZceqwGXHwIBpxzwAacdAAGnHgABpx9AAbcc
-					8AG3GwABtx4AAbcfQAHXHPAB1x0AAdceAAHX
-					H0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRAC
-					Fx4rAhcfAgIXDAI=
-					</data>
+					<data>ASccMAEnHQEBJx6mAScftwE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgFnHPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHHABlx0gAZceqwGXHwIBpxzwAacdAAGnHgABpx9AAbcc8AG3GwABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRACFx4rAhcfAgIXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4862,11 +3706,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					FwFHH5ABhxwwAYcdEAGHHoEBhx8CAhccQAIX
-					HRACFx4hAhcfAgFHDAICFwwC
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABhxwwAYcdEAGHHoEBhx8CAhccQAIXHRACFx4hAhcfAgFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4884,11 +3724,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQEBJx6mAScftwF3HBABdx0BAXce
-					FwF3H5ABpxwwAacdEAGnHqEBpx8DAhccIAIX
-					HRACFx4hAhcfAw==
-					</data>
+					<data>ASccQAEnHQEBJx6mAScftwF3HBABdx0BAXceFwF3H5ABpxwwAacdEAGnHqEBpx8DAhccIAIXHRACFx4hAhcfAw==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4902,11 +3738,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASce
-					oAEnH5ACFxwwAhcdEAIXHiECFx8CAYccQAGH
-					HRABhx6BAYcfAgFHDAICFwwC
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASceoAEnH5ACFxwwAhcdEAIXHiECFx8CAYccQAGHHRABhx6BAYcfAgFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4924,15 +3756,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6gAScfkAE3HPABNx0AATce
-					AAE3H0ABRxzwAUcdAAFHHgABRx9AAXcc8AF3
-					HQABdx4AAXcfQAGHHHABhx0QAYcegQGHHwAB
-					lxzwAZcdAAGXHgABlx9AAaccUAGnHQEBpx4X
-					AacfkAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIX
-					HCACFx0QAhceIQIXHwABpwwC
-					</data>
+					<data>ASccMAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAXcc8AF3HQABdx4AAXcfQAGHHHABhx0QAYcegQGHHwABlxzwAZcdAAGXHgABlx9AAaccUAGnHQEBpx4XAacfkAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIXHCACFx0QAhceIQIXHwABpwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4950,15 +3774,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQEBJx6gAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAXcc8AF3
-					HQABdx4AAXcfQAGHHEABhx0QAYcegQGHHwMB
-					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
-					AacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIX
-					HCACFx0QAhceIQIXHwMBRwwC
-					</data>
+					<data>ASccMAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAXcc8AF3HQABdx4AAXcfQAGHHEABhx0QAYcegQGHHwMBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIXHCACFx0QAhceIQIXHwMBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4976,10 +3792,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6gAScfkAF3HEABdx0AAXce
-					FwF3H5ABdwwCAhccIAIXHRACFx4hAhcfAA==
-					</data>
+					<data>ASccMAEnHQABJx6gAScfkAF3HEABdx0AAXceFwF3H5ABdwwCAhccIAIXHRACFx4hAhcfAA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4993,21 +3806,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					AEcc8ABHHQAARx4AAEcfAABXHPAAVx0AAFce
-					AABXHwAAdxzwAHcdAAB3HgAAdx8AAOcc8ADn
-					HQAA5x4AAOcfAAD3HPAA9x0AAPceAAD3HwAB
-					BxzwAQcdAAEHHgABBx8AASccQAEnHQEBJx6g
-					AScfkAE3HPABNx0AATceAAE3HwABRxwQAUcd
-					AQFHHhcBRx+QAUcMAgFXHPABVx0AAVceAAFX
-					HwABZxzwAWcdAAFnHgABZx8AAXcc8AF3HQAB
-					dx4AAXcfAAGHHDABhx0QAYcegQGHHwMBlxzw
-					AZcdAAGXHgABlx8AAacc8AGnHQABpx4AAacf
-					AAG3HPABtx0AAbceAAG3HwABxxzwAccdAAHH
-					HgABxx8AAdcc8AHXHQAB1x4AAdcfAAHnHPAB
-					5x0AAeceAAHnHwAB9xzwAfcdAAH3HgAB9x8A
-					Agcc8AIHHQACBx4AAgcfAA==
-					</data>
+					<data>AEcc8ABHHQAARx4AAEcfAABXHPAAVx0AAFceAABXHwAAdxzwAHcdAAB3HgAAdx8AAOcc8ADnHQAA5x4AAOcfAAD3HPAA9x0AAPceAAD3HwABBxzwAQcdAAEHHgABBx8AASccQAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3HwABRxwQAUcdAQFHHhcBRx+QAUcMAgFXHPABVx0AAVceAAFXHwABZxzwAWcdAAFnHgABZx8AAXcc8AF3HQABdx4AAXcfAAGHHDABhx0QAYcegQGHHwMBlxzwAZcdAAGXHgABlx8AAacc8AGnHQABpx4AAacfAAG3HPABtx0AAbceAAG3HwABxxzwAccdAAHHHgABxx8AAdcc8AHXHQAB1x4AAdcfAAHnHPAB5x0AAeceAAHnHwAB9xzwAfcdAAH3HgAB9x8AAgcc8AIHHQACBx4AAgcfAA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5025,11 +3824,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6gAScfkAF3HEABdx0AAXce
-					FwF3H5ABdwwCAYcccAGHHRABhx6BAYcfAAIX
-					HCACFx0QAhceIQIXHwA=
-					</data>
+					<data>ASccMAEnHQABJx6gAScfkAF3HEABdx0AAXceFwF3H5ABdwwCAYcccAGHHRABhx6BAYcfAAIXHCACFx0QAhceIQIXHwA=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5047,15 +3842,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfmQF3HEABdx0BAXce
-					FwF3H5ABdwwCAYcc8AGHHQABhx4AAYcfQAGn
-					HPABpx0AAaceAAGnH0ACFxxQAhcdEAIXHiEC
-					Fx8BATcc8AE3HQABNx4AATcfQAFHHPABRx0A
-					AUceAAFHH0ABlxzwAZcdAAGXHgABlx9AAdcc
-					8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHn
-					H0AB9xzwAfcdAAH3HgAB9x9A
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfmQF3HEABdx0BAXceFwF3H5ABdwwCAYcc8AGHHQABhx4AAYcfQAGnHPABpx0AAaceAAGnH0ACFxxQAhcdEAIXHiECFx8BATcc8AE3HQABNx4AATcfQAFHHPABRx0AAUceAAFHH0ABlxzwAZcdAAGXHgABlx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0AB9xzwAfcdAAH3HgAB9x9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5073,11 +3860,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					FwFHH5ABhxwwAYcdEAGHHoEBhx8CAhccQAIX
-					HRACFx4hAhcfAgFHDAICFwwC
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABhxwwAYcdEAGHHoEBhx8CAhccQAIXHRACFx4hAhcfAgFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5095,15 +3878,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
-					AAE3H0ABRxwgAUcdAQFHHhcBRx+QAXcc8AF3
-					HQABdx4AAXcfQAGHHDABhx0QAYcegQGHHwQB
-					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
-					AacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIX
-					HEACFx0QAhceIQIXHwQBRwwC
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwgAUcdAQFHHhcBRx+QAXcc8AF3HQABdx4AAXcfQAGHHDABhx0QAYcegQGHHwQBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIXHEACFx0QAhceIQIXHwQBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5121,12 +3896,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAF3HCABdx0BAXce
-					FwF3H5ABhxwwAYcdEAGHHqsBhx8DAaccQAGn
-					HRABpx6LAacfAwIXHFACFx0QAhceKwIXHwMB
-					RwwCAXcMAgGnDAICFwwC
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAF3HCABdx0BAXceFwF3H5ABhxwwAYcdEAGHHqsBhx8DAaccQAGnHRABpx6LAacfAwIXHFACFx0QAhceKwIXHwMBRwwCAXcMAgGnDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5144,15 +3914,7 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfkAE3HPABNx0AATce
-					AAE3H0ABRxzwAUcdAAFHHgABRx9AAXccIAF3
-					HQEBdx4XAXcfkAGHHDABhx0QAYcegQGHHwMB
-					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
-					AacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
-					AAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIX
-					HEACFx0QAhceIQIXHwMBdwwC
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAXccIAF3HQEBdx4XAXcfkAGHHDABhx0QAYcegQGHHwMBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIXHEACFx0QAhceIQIXHwMBdwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5170,11 +3932,7 @@
 					<key>CodecID</key>
 					<integer>283902617</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQEBJx6gAScfkAFHHBABRx0BAUce
-					FwFHH5ABlxwwAZcdEAGXHoEBlx8EAhccIAIX
-					HRACFx4hAhcfBAFHDAICFwwC
-					</data>
+					<data>ASccQAEnHQEBJx6gAScfkAFHHBABRx0BAUceFwFHH5ABlxwwAZcdEAGXHoEBlx8EAhccIAIXHRACFx4hAhcfBAFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5192,11 +3950,7 @@
 					<key>CodecID</key>
 					<integer>283902617</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccQAEnHQEBJx6gAScfkAF3HBABdx0BAXce
-					FwF3H5ABlxwwAZcdEAGXHoEBlx8EAhccIAIX
-					HRACFx4hAhcfBA==
-					</data>
+					<data>ASccQAEnHQEBJx6gAScfkAF3HBABdx0BAXceFwF3H5ABlxwwAZcdEAGXHoEBlx8EAhccIAIXHRACFx4hAhcfBA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5210,12 +3964,7 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAGHHCABhx2QAYce
-					oAGHH5AB5xwwAecdYQHnHksB5x8BAaccQAGn
-					HTABpx6BAacfAQG3HFABtx1AAbceIQG3HwEB
-					lxxgAZcdkAGXHoEBlx8C
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAGHHCABhx2QAYceoAGHH5AB5xwwAecdYQHnHksB5x8BAaccQAGnHTABpx6BAacfAQG3HFABtx1AAbceIQG3HwEBlxxgAZcdkAGXHoEBlx8C</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5229,14 +3978,7 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5250,12 +3992,7 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfASGHHCAhhx2QIYce
-					oCGHH5AhlxxgIZcdkCGXHqEhlx8CIaccQCGn
-					HTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIh
-					5xwwIecdYSHnHksh5x8B
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfASGHHCAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHqEhlx8CIaccQCGnHTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIh5xwwIecdYSHnHksh5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5269,12 +4006,7 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfASGHHCAhhx2QIYce
-					oCGHH5AhlxxgIZcdkCGXHqEhlx8CIaccQCGn
-					HTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIh
-					5xwwIecdYSHnHksh5x8B
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfASGHHCAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHqEhlx8CIaccQCGnHTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIh5xwwIecdYSHnHksh5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5288,15 +4020,7 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccMAFHHQEBRx4QAUcfkAG3HEABtx0AAbce
-					IQG3HwEBlxwQAZcdAQGXHqABlx+QAYccIAGH
-					HQABhx6BAYcfAQFXHPABVx0AAVceAAFXH0AB
-					ZxzwAWcdAAFnHgABZx9AAacc8AGnHQABpx4A
-					AacfQAHHHPABxx0AAcceAAHHH0AB1xzwAdcd
-					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFH
-					DAI=
-					</data>
+					<data>AUccMAFHHQEBRx4QAUcfkAG3HEABtx0AAbceIQG3HwEBlxwQAZcdAQGXHqABlx+QAYccIAGHHQABhx6BAYcfAQFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAacc8AGnHQABpx4AAacfQAHHHPABxx0AAcceAAHHH0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5314,12 +4038,7 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccEAG3HUABtx4hAbcfAAG3DAIBRxwgAUcd
-					AAFHHhcBRx+QAUcMAgGHHDABhx2QAYcegQGH
-					HwABJxxAAScdAAEnHqYBJx+QAeccYAHnHWAB
-					5x5LAecfAQ==
-					</data>
+					<data>AbccEAG3HUABtx4hAbcfAAG3DAIBRxwgAUcdAAFHHhcBRx+QAUcMAgGHHDABhx2QAYcegQGHHwABJxxAAScdAAEnHqYBJx+QAeccYAHnHWAB5x5LAecfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5337,12 +4056,7 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>
-					AZccEAGXHZEBlx6gAZcfkQFHHCABRx1AAUce
-					IQFHHwEBVxwwAVcdQQFXHhEBVx8BAYccQAGH
-					HZABhx6BAYcfAQG3HFABtx1AAbceIQG3HwIB
-					5xxgAecdYAHnHksB5x8B
-					</data>
+					<data>AZccEAGXHZEBlx6gAZcfkQFHHCABRx1AAUceIQFHHwEBVxwwAVcdQQFXHhEBVx8BAYccQAGHHZABhx6BAYcfAQG3HFABtx1AAbceIQG3HwIB5xxgAecdYAHnHksB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5360,11 +4074,7 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4hAUcfAQFXHCABVx0AAVce
-					EwFXH5ABtxwwAbcdEAG3HiEBtx8BAYccQAGH
-					HTABhx6hAYcfkAGXHFABlx0QAZcegQGXHwI=
-					</data>
+					<data>AUccEAFHHUABRx4hAUcfAQFXHCABVx0AAVceEwFXH5ABtxwwAbcdEAG3HiEBtx8BAYccQAGHHTABhx6hAYcfkAGXHFABlx0QAZcegQGXHwI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5378,10 +4088,7 @@
 					<key>CodecID</key>
 					<integer>283903587</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
-					EwFHH5ACFxwwAhcdEAIXHiECFx8CAUcMAg==
-					</data>
+					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ACFxwwAhcdEAIXHiECFx8CAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5399,12 +4106,7 @@
 					<key>CodecID</key>
 					<integer>283903587</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAGHHCABhx0QAYce
-					gQGHHwIBlxwwAZcdAAGXHqABlx+QAdccQAHX
-					HYAB1x4FAdcfQAHnHFAB5x0QAeceRQHnHwAC
-					FxxgAhcdEAIXHiECFx8BAUcMAg==
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAGHHCABhx0QAYcegQGHHwIBlxwwAZcdAAGXHqABlx+QAdccQAHXHYAB1x4FAdcfQAHnHFAB5x0QAeceRQHnHwACFxxgAhcdEAIXHiECFx8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5422,13 +4124,7 @@
 					<key>CodecID</key>
 					<integer>283903587</integer>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4BIUcfASF3HCAhdx0AIXce
-					EyF3H5AhFxwwIRcdYCEXHkQhFx8BIeccQCHn
-					HRAh5x5WIecfECGHHFAhhx0AIYceoCGHH5Ah
-					lxxgIZcdACGXHqAhlx+QIacccCGnHTAhpx6B
-					IacfASIXHJAiFx1AIhceISIXHwE=
-					</data>
+					<data>IUccECFHHUAhRx4BIUcfASF3HCAhdx0AIXceEyF3H5AhFxwwIRcdYCEXHkQhFx8BIeccQCHnHRAh5x5WIecfECGHHFAhhx0AIYceoCGHH5AhlxxgIZcdACGXHqAhlx+QIacccCGnHTAhpx6BIacfASIXHJAiFx1AIhceISIXHwE=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5444,12 +4140,7 @@
 					<key>Comment</key>
 					<string>Custom ALC663 for Asus N56/76 by m-dudarev</string>
 					<key>ConfigData</key>
-					<data>
-					AZccEAGXHQABlx6gAZcfkAGHHCABhx0QAYce
-					gQGHHwIBRxwwAUcdAAFHHhABRx+QAUcMAgIX
-					HEACFx0QAhceIQIXHwIBFxzwARcdAAEXHgAB
-					Fx9AAecc8AHnHQAB5x4AAecfQA==
-					</data>
+					<data>AZccEAGXHQABlx6gAZcfkAGHHCABhx0QAYcegQGHHwIBRxwwAUcdAAFHHhABRx+QAUcMAgIXHEACFx0QAhceIQIXHwIBFxzwARcdAAEXHgABFx9AAecc8AHnHQAB5x4AAecfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5469,13 +4160,7 @@
 					<key>Comment</key>
 					<string>Custom by alex1960 for ASUS N71J</string>
 					<key>ConfigData</key>
-					<data>
-					AUccAAFHHQEBRx4TAUcfmQA3HBAANx0AADce
-					VgA3HxgCFxwgAhcdQAIXHiECFx8BAbccMAG3
-					HUABtx4hAbcfAQHnHEAB5x0BAeceQwHnH5kB
-					hxxQAYcdCQGHHqMBhx+ZAZccYAGXHZwBlx6B
-					AZcfAQF3HPABdx0BAXceEwF3H5k=
-					</data>
+					<data>AUccAAFHHQEBRx4TAUcfmQA3HBAANx0AADceVgA3HxgCFxwgAhcdQAIXHiECFx8BAbccMAG3HUABtx4hAbcfAQHnHEAB5x0BAeceQwHnH5kBhxxQAYcdCQGHHqMBhx+ZAZccYAGXHZwBlx6BAZcfAQF3HPABdx0BAXceEwF3H5k=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5489,12 +4174,7 @@
 					<key>CodecID</key>
 					<integer>283903589</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfmQGnHCABpx0QAace
-					gQGnH5MBVxxAAVcdAQFXHhMBVx+ZAZccUAGX
-					HRABlx4hAZcfAwG3HGABtx0QAbceIQG3HwMB
-					5xxwAecdEAHnHkUB5x8D
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfmQGnHCABpx0QAacegQGnH5MBVxxAAVcdAQFXHhMBVx+ZAZccUAGXHRABlx4hAZcfAwG3HGABtx0QAbceIQG3HwMB5xxwAecdEAHnHkUB5x8D</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5508,12 +4188,7 @@
 					<key>CodecID</key>
 					<integer>283903589</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccUAEnHQABJx6gAScfkAFXHBABVx0AAVce
-					EwFXH5ABVwwCAZccIAGXHRABlx4hAZcfAAGn
-					HEABpx0QAacegQGnHwABtxxgAbcdEAG3HiEB
-					tx8AAdcc8AHXHQAB1x6DAdcfUA==
-					</data>
+					<data>ASccUAEnHQABJx6gAScfkAFXHBABVx0AAVceEwFXH5ABVwwCAZccIAGXHRABlx4hAZcfAAGnHEABpx0QAacegQGnHwABtxxgAbcdEAG3HiEBtx8AAdcc8AHXHQAB1x6DAdcfUA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5527,12 +4202,7 @@
 					<key>Comment</key>
 					<string>ALC668 Mirone Laptop Patch</string>
 					<key>ConfigData</key>
-					<data>
-					ABJxwQAScdAAEnHqABJx+QAUccIAFHHQABRx
-					4XAUcfkAFXHDABVx0QAVceIQFXHwEBZxxAAW
-					cdAAFnHgABZx9AAbccUAG3HRABtx6BAbcfAg
-					HXHGAB1x0AAdcewAHXH0ABRwwA==
-					</data>
+					<data>ABJxwQAScdAAEnHqABJx+QAUccIAFHHQABRx4XAUcfkAFXHDABVx0QAVceIQFXHwEBZxxAAWcdAAFnHgABZx9AAbccUAG3HRABtx6BAbcfAgHXHGAB1x0AAdcewAHXH0ABRwwA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5546,11 +4216,7 @@
 					<key>Comment</key>
 					<string>Custom ALC668 by lazzy for laptop ASUS G551JM</string>
 					<key>ConfigData</key>
-					<data>
-					ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUce
-					FwFHH5ABVxwgAVcdEAFXHiEBVx8AAbccQAG3
-					HRABtx6BAbcfAAFHDAI=
-					</data>
+					<data>ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABVxwgAVcdEAFXHiEBVx8AAbccQAG3HRABtx6BAbcfAAFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5568,33 +4234,7 @@
 					<key>Comment</key>
 					<string>ALC668 syscl Laptop Patch (DELL Precision M3800)</string>
 					<key>ConfigData</key>
-					<data>
-					ASccAQEnHQEBJx6gAScfkAFHHAIBRx0BAUce
-					FwFHH5ABRwwCAVccAwFXHRABVx4rAVcfAwFX
-					DAIBZxzwAWcdAAFnHgABZx9AAYcc8AGHHQAB
-					hx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzw
-					AacdAAGnHgABpx9AAbccBAG3HRABtx6LAbcf
-					AwHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHn
-					HgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIFAAEC
-					BL6+AgUAAgIEqqoCBQADAgQAAAIFAAQCBAGA
-					AgUABgIEAAACBQAHAgQPgAIFAAgCBAAxAgUA
-					CgIEAGACBQALAgQAAAIFAAwCBHz3AgUADQIE
-					EIACBQAOAgR/fwIFAA8CBMzMAgUAEAIE3cwC
-					BQARAgQAAQIFABMCBAAAAgUAFAIEKqACBQAX
-					AgSpQAIFABkCBAAAAgUAGgIEAAACBQAbAgQA
-					AAIFABwCBAAAAgUAHQIEAAACBQAeAgR0GAIF
-					AB8CBAgEAgUAIAIEQgACBQAhAgQEaAIFACIC
-					BIzMAgUAIwIEAlACBQAkAgR0GAIFACcCBAAA
-					AgUAKAIEjMwCBQAqAgT/AAIFACsCBIAAAgUA
-					pwIE/wACBQCoAgSAAAIFAKoCBC4XAgUAqwIE
-					oMACBQCsAgQAAAIFAK0CBAAAAgUArgIEKsYC
-					BQCvAgSkgAIFALACBAAAAgUAsQIEAAACBQCy
-					AgQAAAIFALMCBAAAAgUAtAIEAAACBQC1AgQQ
-					QAIFALYCBNaXAgUAtwIEkCsCBQC4AgTWlwIF
-					ALkCBJArAgUAugIEuLoCBQC7AgSqqwIFALwC
-					BKqvAgUAvQIEaqoCBQC+AgQcAgIFAMACBAD/
-					AgUAwQIED6Y=
-					</data>
+					<data>ASccAQEnHQEBJx6gAScfkAFHHAIBRx0BAUceFwFHH5ABRwwCAVccAwFXHRABVx4rAVcfAwFXDAIBZxzwAWcdAAFnHgABZx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccBAG3HRABtx6LAbcfAwHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIFAAECBL6+AgUAAgIEqqoCBQADAgQAAAIFAAQCBAGAAgUABgIEAAACBQAHAgQPgAIFAAgCBAAxAgUACgIEAGACBQALAgQAAAIFAAwCBHz3AgUADQIEEIACBQAOAgR/fwIFAA8CBMzMAgUAEAIE3cwCBQARAgQAAQIFABMCBAAAAgUAFAIEKqACBQAXAgSpQAIFABkCBAAAAgUAGgIEAAACBQAbAgQAAAIFABwCBAAAAgUAHQIEAAACBQAeAgR0GAIFAB8CBAgEAgUAIAIEQgACBQAhAgQEaAIFACICBIzMAgUAIwIEAlACBQAkAgR0GAIFACcCBAAAAgUAKAIEjMwCBQAqAgT/AAIFACsCBIAAAgUApwIE/wACBQCoAgSAAAIFAKoCBC4XAgUAqwIEoMACBQCsAgQAAAIFAK0CBAAAAgUArgIEKsYCBQCvAgSkgAIFALACBAAAAgUAsQIEAAACBQCyAgQAAAIFALMCBAAAAgUAtAIEAAACBQC1AgQQQAIFALYCBNaXAgUAtwIEkCsCBQC4AgTWlwIFALkCBJArAgUAugIEuLoCBQC7AgSqqwIFALwCBKqvAgUAvQIEaqoCBQC+AgQcAgIFAMACBAD/AgUAwQIED6Y=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5612,12 +4252,7 @@
 					<key>Comment</key>
 					<string>ALC668 Mirone Laptop Patch (Asus N750Jk)</string>
 					<key>ConfigData</key>
-					<data>
-					ABJxwQAScdAAEnHqABJx+QAUccIAFHHQABRx
-					4XAUcfkAFXHDABVx0QAVceIQFXHwEBZxxAAW
-					cdAAFnHgABZx9AAbccUAG3HRABtx6BAbcfAg
-					HXHGAB1x0AAdcewAHXH0ABRwwA==
-					</data>
+					<data>ABJxwQAScdAAEnHqABJx+QAUccIAFHHQABRx4XAUcfkAFXHDABVx0QAVceIQFXHwEBZxxAAWcdAAFnHgABZx9AAbccUAG3HRABtx6BAbcfAgHXHGAB1x0AAdcewAHXH0ABRwwA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5631,15 +4266,7 @@
 					<key>Comment</key>
 					<string>ALC668 Custom (Asus N750JV)</string>
 					<key>ConfigData</key>
-					<data>
-					ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUce
-					FwFHH5ABVxwfAVcdEAFXHiEBVx8DAWcc8AFn
-					HQABZx4AAWcfQAGHHPABhx0AAYceAAGHH0AB
-					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
-					AacfQAG3HDABtx0QAbcegQG3HwMB1xzwAdcd
-					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAH3
-					HPAB9x0AAfceAAH3H0ABRwwCAVcMAg==
-					</data>
+					<data>ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABVxwfAVcdEAFXHiEBVx8DAWcc8AFnHQABZx4AAWcfQAGHHPABhx0AAYceAAGHH0ABlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HDABtx0QAbcegQG3HwMB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAH3HPAB9x0AAfceAAH3H0ABRwwCAVcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5657,17 +4284,7 @@
 					<key>Comment</key>
 					<string>Custom ALC670 by Alex Auditore</string>
 					<key>ConfigData</key>
-					<data>
-					AbccQAG3HRABtx4rAbcfAQFXHDABVx0BAVce
-					EwFXH5ABJxwQAScdAQEnHqABJx+QAaccUAGn
-					HTEBpx6BAacfAQGXHCABlx2QAZcegQGXHwEB
-					5xxgAecdEQHnHksB5x8BARcc8AEXHQABFx4A
-					ARcfQAE3HPABNx0AATceAAE3H0ABRxzwAUcd
-					AAFHHgABRx9AAWcc8AFnHQABZx4AAWcfQAF3
-					HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgAB
-					hx9AAdcc8AHXHQAB1x4AAdcfQAIXHPACFx0A
-					AhceAAIXH0A=
-					</data>
+					<data>AbccQAG3HRABtx4rAbcfAQFXHDABVx0BAVceEwFXH5ABJxwQAScdAQEnHqABJx+QAaccUAGnHTEBpx6BAacfAQGXHCABlx2QAZcegQGXHwEB5xxgAecdEQHnHksB5x8BARcc8AEXHQABFx4AARcfQAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAdcc8AHXHQAB1x4AAdcfQAIXHPACFx0AAhceAAIXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5681,10 +4298,7 @@
 					<key>Comment</key>
 					<string>MacPeet - ALC671 for Fujitsu-Siemens D3433-S (Q170 chip)</string>
 					<key>ConfigData</key>
-					<data>
-					AYccIAGHHTABhx6BAYcfAQIXHDACFx1AAhce
-					AQIXHwECFwwC
-					</data>
+					<data>AYccIAGHHTABhx6BAYcfAQIXHDACFx1AAhceAQIXHwECFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5698,12 +4312,7 @@
 					<key>Comment</key>
 					<string>MacPeet - ALC671 for Fujitsu  Esprimo C720</string>
 					<key>ConfigData</key>
-					<data>
-					IXccECF3HQAhdx4TIXcfkCFHHCAhRx0QIUce
-					ISFHHwIhRwwCIhccMCIXHUAiFx4RIhcfkSIX
-					DAIhlxxQIZcdECGXHoEhlx8CIYccYCGHHTAh
-					hx6BIYcfAQ==
-					</data>
+					<data>IXccECF3HQAhdx4TIXcfkCFHHCAhRx0QIUceISFHHwIhRwwCIhccMCIXHUAiFx4RIhcfkSIXDAIhlxxQIZcdECGXHoEhlx8CIYccYCGHHTAhhx6BIYcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5739,12 +4348,7 @@
 					<key>CodecID</key>
 					<integer>283904130</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
-					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
-					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
-					5xyQAecd4AHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5758,14 +4362,7 @@
 					<key>CodecID</key>
 					<integer>283904130</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5781,14 +4378,7 @@
 					<key>Comment</key>
 					<string>Mirone - Realtek ALC883 by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5802,15 +4392,7 @@
 					<key>Comment</key>
 					<string>toleda ALC885</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfASFXHCAhVx0QIVce
-					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
-					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
-					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfccoCH3HQEh9x7LIfcfASEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfASFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfccoCH3HQEh9x7LIfcfASEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5826,15 +4408,7 @@
 					<key>Comment</key>
 					<string>Custom ALC885 by alex1960</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfASFXHCAhVx0QIVce
-					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
-					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
-					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfccoCH3HQEh9x7LIfcfASEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfASFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfccoCH3HQEh9x7LIfcfASEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5850,14 +4424,7 @@
 					<key>Comment</key>
 					<string>MacPeet - ALC885 for GA-G33M-DS2R</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkSFXHCAhVx0QIVce
-					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIYccQCGH
-					HZAhhx6gIYcfkCGnHFAhpx0wIacegSGnHwEh
-					lxxgIZcdkCGXHoEhlx8CIbcccCG3HUAhtx4h
-					IbcfAiHnHJAh5x1hIeceSyHnHwEh9xygIfcd
-					ASH3Hssh9x8B
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkSFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIYccQCGHHZAhhx6gIYcfkCGnHFAhpx0wIacegSGnHwEhlxxgIZcdkCGXHoEhlx8CIbcccCG3HUAhtx4hIbcfAiHnHJAh5x1hIeceSyHnHwEh9xygIfcdASH3Hssh9x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5871,15 +4438,7 @@
 					<key>Comment</key>
 					<string>Toleda ALC887</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
-					ECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3
-					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
-					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
-					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
-					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
-					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5897,15 +4456,7 @@
 					<key>Comment</key>
 					<string>Toleda ALC887</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcd
-					ACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
-					HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEh
-					hx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0Q
-					IaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
-					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
-					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcdACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEhhx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0QIaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5923,15 +4474,7 @@
 					<key>Comment</key>
 					<string>Toleda ALC887</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
-					ECFXHgEhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
-					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
-					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
-					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
-					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
-					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5949,12 +4492,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
-					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
-					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB
-					5xyQAecdYAHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5972,14 +4510,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5997,11 +4528,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkQFHDAIBtxwgAbcd
-					QAG3HiEBtx8CAbcMAgGHHDABhx2QAYceoQGH
-					H5EBlxxAAZcdkQGXHoEBlx+SAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkQFHDAIBtxwgAbcdQAG3HiEBtx8CAbcMAgGHHDABhx2QAYceoQGHH5EBlxxAAZcdkQGXHoEBlx+SAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6019,12 +4546,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					AbccAAG3HUABtx4hAbcfAQGHHBABhx2QAYce
-					oAGHH5EBlxwgAZcdkAGXHoEBlx8BAUccMAFH
-					HUABRx4RAUcfkQGnHEABpx0wAacegQGnHwEB
-					5xxQAecdYQHnHksB5x8BAUcMAg==
-					</data>
+					<data>AbccAAG3HUABtx4hAbcfAQGHHBABhx2QAYceoAGHH5EBlxwgAZcdkAGXHoEBlx8BAUccMAFHHUABRx4RAUcfkQGnHEABpx0wAacegQGnHwEB5xxQAecdYQHnHksB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6042,13 +4564,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
-					ASFXHwEhhxxAIYcdkCGHHqAhhx+QIaccUCGn
-					HTAhpx6BIacfASGXHGAhlx2QIZcegSGXHwIh
-					txxwIbcdQCG3HiEhtx8CIecckCHnHWEh5x5L
-					IecfAQ==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhhxxAIYcdkCGHHqAhhx+QIaccUCGnHTAhpx6BIacfASGXHGAhlx2QIZcegSGXHwIhtxxwIbcdQCG3HiEhtx8CIecckCHnHWEh5x5LIecfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6062,12 +4578,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkSFHDAIhhxxAIYcd
-					YCGHHgEhhx8BIaccUCGnHRAhpx4BIacfASGX
-					HGAhlx2QIZceoSGXH5EhtxxwIbcdQCG3HiEh
-					tx8CIecckCHnHWEh5x5LIecfAQ==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkSFHDAIhhxxAIYcdYCGHHgEhhx8BIaccUCGnHRAhpx4BIacfASGXHGAhlx2QIZceoSGXH5EhtxxwIbcdQCG3HiEhtx8CIecckCHnHWEh5x5LIecfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6081,14 +4592,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccAAFHHUABRx4BAUcfAQFnHBABZx1gAWce
-					AQFnHwEBVxwgAVcdEAFXHgEBVx8BAXccMAF3
-					HSABdx4BAXcfAQG3HEABtx1AAbceIQG3HwIB
-					FxxQARcdAQEXHkYBFx+ZAYccYAGHHZABhx6g
-					AYcfkAGnHHABpx0wAacegQGnHwEBlxyAAZcd
-					kAGXHoEBlx8CAUcMAg==
-					</data>
+					<data>AUccAAFHHUABRx4BAUcfAQFnHBABZx1gAWceAQFnHwEBVxwgAVcdEAFXHgEBVx8BAXccMAF3HSABdx4BAXcfAQG3HEABtx1AAbceIQG3HwIBFxxQARcdAQEXHkYBFx+ZAYccYAGHHZABhx6gAYcfkAGnHHABpx0wAacegQGnHwEBlxyAAZcdkAGXHoEBlx8CAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6106,17 +4610,7 @@
 					<key>Comment</key>
 					<string>Custom by klblk ALC887 for GA-Q87TN</string>
 					<key>ConfigData</key>
-					<data>
-					IRcc8CEXHQAhFx4AIRcfQCEnHPAhJx0AISce
-					ACEnH0AhRxzwIUcdACFHHgAhRx9AIVcc8CFX
-					HQAhVx4AIVcfQCFnHPAhZx0AIWceACFnH0Ah
-					dxzwIXcdACF3HgAhdx9AIYcccCGHHZAhhx6B
-					IYcfASGXHPAhlx0AIZceACGXH0AhpxwgIacd
-					QCGnHgEhpx8BIbcc8CG3HQAhtx4AIbcfQCHH
-					HPAhxx0AIcceACHHH0Ah1xzwIdcdACHXHgAh
-					1x9AIecc8CHnHQAh5x4AIecfQCH3HPAh9x0A
-					IfceACH3H0A=
-					</data>
+					<data>IRcc8CEXHQAhFx4AIRcfQCEnHPAhJx0AISceACEnH0AhRxzwIUcdACFHHgAhRx9AIVcc8CFXHQAhVx4AIVcfQCFnHPAhZx0AIWceACFnH0AhdxzwIXcdACF3HgAhdx9AIYcccCGHHZAhhx6BIYcfASGXHPAhlx0AIZceACGXH0AhpxwgIacdQCGnHgEhpx8BIbcc8CG3HQAhtx4AIbcfQCHHHPAhxx0AIcceACHHH0Ah1xzwIdcdACHXHgAh1x9AIecc8CHnHQAh5x4AIecfQCH3HPAh9x0AIfceACH3H0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6130,12 +4624,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccAAFHHUABRx4BAUcfAQG3HBABtx1AAbce
-					IQG3HwIBhxwgAYcdkAGHHqABhx+QAaccMAGn
-					HTABpx6BAacfAQGXHEABlx2QAZcegQGXHwIB
-					RwwC
-					</data>
+					<data>AUccAAFHHUABRx4BAUcfAQG3HBABtx1AAbceIQG3HwIBhxwgAYcdkAGHHqABhx+QAaccMAGnHTABpx6BAacfAQGXHEABlx2QAZcegQGXHwIBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6153,11 +4642,7 @@
 					<key>Comment</key>
 					<string>0th3r ALC887 for PRIME B250-PLUS</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4BAUcfAQG3HCABtx1BAbce
-					IQG3HwIBhxxAAYcdkAGHHoEBhx8BAZccUAGX
-					HZEBlx6BAZcfAg==
-					</data>
+					<data>AUccEAFHHUABRx4BAUcfAQG3HCABtx1BAbceIQG3HwIBhxxAAYcdkAGHHoEBhx8BAZccUAGXHZEBlx6BAZcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6171,12 +4656,7 @@
 					<key>Comment</key>
 					<string>ALC887 for Asus PRIME Z270-P (full Rear and Front, non auto-switch) by ctich</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4BAUcfAQFHDAIBtxwgAbcd
-					QAG3HiEBtx8CAbcMAgEXHDABFx0BARceRgEX
-					H5ABhxxAAYcdkAGHHqABhx+RAaccTwGnHTAB
-					px6BAacfAQGXHFABlx2RAZcegQGXHwI=
-					</data>
+					<data>AUccEAFHHUABRx4BAUcfAQFHDAIBtxwgAbcdQAG3HiEBtx8CAbcMAgEXHDABFx0BARceRgEXH5ABhxxAAYcdkAGHHqABhx+RAaccTwGnHTABpx6BAacfAQGXHFABlx2RAZcegQGXHwI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6194,12 +4674,7 @@
 					<key>Comment</key>
 					<string>ALC887 for Asus PRIME Z270-P (Rear LineOut1, Mic - LineOut2, LineIn - LineOut3 - 5.1 and Front, non auto-switch) by ctich</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4BAUcfAQFHDAIBhxwQAYcd
-					YAGHHgEBhx8BAaccEAGnHRABpx4BAacfAQG3
-					HCABtx1AAbceIQG3HwIBtwwCARccMAEXHQEB
-					Fx5GARcfkAGXHFABlx2RAZcegQGXHwI=
-					</data>
+					<data>AUccEAFHHUABRx4BAUcfAQFHDAIBhxwQAYcdYAGHHgEBhx8BAaccEAGnHRABpx4BAacfAQG3HCABtx1AAbceIQG3HwIBtwwCARccMAEXHQEBFx5GARcfkAGXHFABlx2RAZcegQGXHwI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6217,17 +4692,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					IRccYCEXHQEhFx5DIRcfmSEnHPAhJx0AISce
-					ACEnH0AhRxyAIUcdQCFHHhEhRx8BIUcMAiFX
-					HIIhVx0QIVceASFXHwEhZxyBIWcdYCFnHgEh
-					Zx8BIXccgiF3HSAhdx4BIXcfASGHHHAhhx2Q
-					IYceoSGHHwEhlxxwIZcdkCGXHqEhlx8CIacc
-					ICGnHTAhpx6BIacfASG3HFAhtx1AIbceISG3
-					HwIhtwwCIccc8CHHHQAhxx4AIccfQCHXHPAh
-					1x0AIdceACHXH0Ah5xzwIecdACHnHgAh5x9A
-					Ifcc8CH3HQAh9x4AIfcfQA==
-					</data>
+					<data>IRccYCEXHQEhFx5DIRcfmSEnHPAhJx0AISceACEnH0AhRxyAIUcdQCFHHhEhRx8BIUcMAiFXHIIhVx0QIVceASFXHwEhZxyBIWcdYCFnHgEhZx8BIXccgiF3HSAhdx4BIXcfASGHHHAhhx2QIYceoSGHHwEhlxxwIZcdkCGXHqEhlx8CIaccICGnHTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIhtwwCIccc8CHHHQAhxx4AIccfQCHXHPAh1x0AIdceACHXH0Ah5xzwIecdACHnHgAh5x9AIfcc8CH3HQAh9x4AIfcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6241,12 +4706,7 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfASGHHFAhhx2QIYce
-					oCGHH5AhlxxgIZcdkCGXHoEhlx8CIacccCGn
-					HTAhpx6BIacfASG3HIAhtx1AIbceISG3HwIh
-					5xyQIecdYCHnHkUh5x8B
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfASGHHFAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIacccCGnHTAhpx6BIacfASG3HIAhtx1AIbceISG3HwIh5xyQIecdYCHnHkUh5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6260,15 +4720,7 @@
 					<key>Comment</key>
 					<string>toleda ALC888</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
-					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
-					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
-					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6282,15 +4734,7 @@
 					<key>Comment</key>
 					<string>toleda ALC888</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFXHPAhVx0AIVce
-					ACFXH0AhZxzwIWcdACFnHgAhZx9AIXcc8CF3
-					HQAhdx4AIXcfQCGHHEAhhx1gIYceASGHHwEh
-					lxxgIZcdkCGXHqAhlx+QIaccUCGnHRAhpx4B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFXHPAhVx0AIVceACFXH0AhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx1gIYceASGHHwEhlxxgIZcdkCGXHqAhlx+QIaccUCGnHRAhpx4BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6304,15 +4748,7 @@
 					<key>Comment</key>
 					<string>toleda ALC888</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
-					ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3
-					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
-					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6326,13 +4762,7 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQABJx6gAScfmQFHHCABRx1AAUce
-					IQFHHwEBtxwwAbcdAQG3HhMBtx+ZAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYcegQGHHwEB
-					pxxgAacdMAGnHoEBpx8BAecccAHnHUAB5x5F
-					AecfAQFHDAI=
-					</data>
+					<data>ASccEAEnHQABJx6gAScfmQFHHCABRx1AAUceIQFHHwEBtxwwAbcdAQG3HhMBtx+ZAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYcegQGHHwEBpxxgAacdMAGnHoEBpx8BAecccAHnHUAB5x5FAecfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6350,12 +4780,7 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
-					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
-					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
-					5xyQAecd4AHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6369,14 +4794,7 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6390,12 +4808,7 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHRABRx4hAUcfAQFHDAIBhxwwAYcd
-					EAGHHqEBhx8BASccQAEnHQABJx6jAScfkAF3
-					HFABdx0AAXceEwF3H5ABpxxgAacdEAGnHoEB
-					px8BAecccAHnHRAB5x5FAecfAQ==
-					</data>
+					<data>AUccEAFHHRABRx4hAUcfAQFHDAIBhxwwAYcdEAGHHqEBhx8BASccQAEnHQABJx6jAScfkAF3HFABdx0AAXceEwF3H5ABpxxgAacdEAGnHoEBpx8BAecccAHnHRAB5x5FAecfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6413,12 +4826,7 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAFHDAIBJxxAAScd
-					AAEnHqMBJx+QAVccUAFXHRABVx4hAVcfAAFX
-					DAIBpxxgAacdMAGnHoEBpx8AAecccAHnHRAB
-					5x5FAecfAA==
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAFHDAIBJxxAAScdAAEnHqMBJx+QAVccUAFXHRABVx4hAVcfAAFXDAIBpxxgAacdMAGnHoEBpx8AAecccAHnHRAB5x5FAecfAA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6432,13 +4840,7 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAFHDAIBdxwgAXcd
-					AAF3HhMBdx+QAeccMAHnHRAB5x5EAecfAAGH
-					HEABhx0QAYceoQGHHwABJxxQAScdAAEnHqMB
-					Jx+QAaccYAGnHRABpx6BAacfAAG3HHABtx0Q
-					AbceIQG3HwA=
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAFHDAIBdxwgAXcdAAF3HhMBdx+QAeccMAHnHRAB5x5EAecfAAGHHEABhx0QAYceoQGHHwABJxxQAScdAAEnHqMBJx+QAaccYAGnHRABpx6BAacfAAG3HHABtx0QAbceIQG3HwA=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6456,12 +4858,7 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQABRx4TAUcfkAFHDAIBdxwgAXcd
-					EAF3HhMBdx+QAeccMAHnHRAB5x5FAecfAAGX
-					HEABlx0AAZceowGXH5ABhxxQAYcdEAGHHoEB
-					hx8AAVccYAFXHRABVx4hAVcfAAFXDAI=
-					</data>
+					<data>AUccEAFHHQABRx4TAUcfkAFHDAIBdxwgAXcdEAF3HhMBdx+QAeccMAHnHRAB5x5FAecfAAGXHEABlx0AAZceowGXH5ABhxxQAYcdEAGHHoEBhx8AAVccYAFXHRABVx4hAVcfAAFXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6479,15 +4876,7 @@
 					<key>Comment</key>
 					<string>ALC889, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
-					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
-					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
-					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6501,15 +4890,7 @@
 					<key>Comment</key>
 					<string>ALC889, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
-					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
-					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
-					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6523,15 +4904,7 @@
 					<key>Comment</key>
 					<string>ALC889, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
-					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
-					ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3
-					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6545,12 +4918,7 @@
 					<key>Comment</key>
 					<string>MacPeet ALC889 Medion P4020 D</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4hAUcfAQFHDAIBtxwgAbcd
-					AAG3HhMBtx+QAeccMAHnHWAB5x5EAecfAQGX
-					HFABlx0AAZceowGXH5ABpxxgAacdMAGnHoEB
-					px8B
-					</data>
+					<data>AUccEAFHHUABRx4hAUcfAQFHDAIBtxwgAbcdAAG3HhMBtx+QAeccMAHnHWAB5x5EAecfAQGXHFABlx0AAZceowGXH5ABpxxgAacdMAGnHoEBpx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6568,17 +4936,7 @@
 					<key>Comment</key>
 					<string>alc889, Custom by Sergey_Galan</string>
 					<key>ConfigData</key>
-					<data>
-					IRcc8CEXHQAhFx4AIRcfQCEnHPAhJx0AISce
-					ACEnH0AhRxwwIUcdQSFHHhEhRx8BIVcc8CFX
-					HQAhVx4AIVcfQCFnHPAhZx0AIWceACFnH0Ah
-					dxzwIXcdACF3HgAhdx9AIYccECGHHZEhhx6g
-					IYcfkCGXHCAhlx2QIZcegSGXHwEhpxzwIacd
-					ACGnHgAhpx9AIbccgCG3HUAhtx4hIbcfASHH
-					HPAhxx0AIcceACHHH0Ah1xzwIdcdACHXHgAh
-					1x9AIecckCHnHSEh5x5LIecfASH3HPAh9x0A
-					IfceACH3H0A=
-					</data>
+					<data>IRcc8CEXHQAhFx4AIRcfQCEnHPAhJx0AISceACEnH0AhRxwwIUcdQSFHHhEhRx8BIVcc8CFXHQAhVx4AIVcfQCFnHPAhZx0AIWceACFnH0AhdxzwIXcdACF3HgAhdx9AIYccECGHHZEhhx6gIYcfkCGXHCAhlx2QIZcegSGXHwEhpxzwIacdACGnHgAhpx9AIbccgCG3HUAhtx4hIbcfASHHHPAhxx0AIcceACHHH0Ah1xzwIdcdACHXHgAh1x9AIecckCHnHSEh5x5LIecfASH3HPAh9x0AIfceACH3H0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6592,11 +4950,7 @@
 					<key>CodecID</key>
 					<integer>283904103</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccIAF3HRABdx4hAXcfAgGHHDABhx2QAYce
-					gQGHHwEBtxxAAbcdMAG3HoEBtx8BAhccYAIX
-					HQACFx4RAhcfAAIXDAI=
-					</data>
+					<data>AXccIAF3HRABdx4hAXcfAgGHHDABhx2QAYcegQGHHwEBtxxAAbcdMAG3HoEBtx8BAhccYAIXHQACFx4RAhcfAAIXDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6610,12 +4964,7 @@
 					<key>CodecID</key>
 					<integer>283904103</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HUABdx4hAXcfAQFnHDABZx0wAWce
-					gQFnHwEBhxxAAYcdkAGHHqEBhx+RAaccYAGn
-					HZABpx6BAacfAgHnHHAB5x0AAeceRgHnH5AC
-					FxyAAhcdQAIXHhECFx8B
-					</data>
+					<data>AXccEAF3HUABdx4hAXcfAQFnHDABZx0wAWcegQFnHwEBhxxAAYcdkAGHHqEBhx+RAaccYAGnHZABpx6BAacfAgHnHHAB5x0AAeceRgHnH5ACFxyAAhcdQAIXHhECFx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6629,15 +4978,7 @@
 					<key>Comment</key>
 					<string>ALC892, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
-					ECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3
-					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
-					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
-					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
-					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
-					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6655,15 +4996,7 @@
 					<key>Comment</key>
 					<string>ALC892, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcd
-					ACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
-					HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEh
-					hx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0Q
-					IaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
-					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
-					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcdACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEhhx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0QIaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6681,15 +5014,7 @@
 					<key>Comment</key>
 					<string>ALC892, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
-					ECFXHgEhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
-					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
-					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
-					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
-					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
-					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6707,13 +5032,7 @@
 					<key>CodecID</key>
 					<integer>283904146</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHZABJx6gAScfmQFHHCABRx1AAUce
-					IQFHHwEBdxwwAXcdEAF3HgEBdx8BAYccQAGH
-					HZABhx6BAYcfAQGnHFABpx0wAacegQGnHwEB
-					txxgAbcdQAG3HhMBtx+ZAecccAHnHWAB5x5F
-					AecfAQG3DAI=
-					</data>
+					<data>ASccEAEnHZABJx6gAScfmQFHHCABRx1AAUceIQFHHwEBdxwwAXcdEAF3HgEBdx8BAYccQAGHHZABhx6BAYcfAQGnHFABpx0wAacegQGnHwEBtxxgAbcdQAG3HhMBtx+ZAecccAHnHWAB5x5FAecfAQG3DAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6727,12 +5046,7 @@
 					<key>Comment</key>
 					<string>ALC892, Mirone</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
-					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
-					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
-					5xyQAecd4AHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6746,14 +5060,7 @@
 					<key>Comment</key>
 					<string>ALC892, Mirone</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6785,14 +5092,7 @@
 					<key>Comment</key>
 					<string>MacPeet - alc892 for MSi Z97S SLI Krait Edition</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkQG3HCABRwwCAbcd
-					QAG3HiEBtx8CAbcMAgGHHDABhx2QAYceoQGH
-					H5EBVxxQAVcdEAFXHgEBVx8BAWccYAFnHWAB
-					Zx4BAWcfAQF3HHABdx0gAXceAQF3HwEBlxyA
-					AZcdkAGXHoEBlx8CAacckAGnHTABpx6BAacf
-					AQ==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkQG3HCABRwwCAbcdQAG3HiEBtx8CAbcMAgGHHDABhx2QAYceoQGHH5EBVxxQAVcdEAFXHgEBVx8BAWccYAFnHWABZx4BAWcfAQF3HHABdx0gAXceAQF3HwEBlxyAAZcdkAGXHoEBlx8CAacckAGnHTABpx6BAacfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6810,12 +5110,7 @@
 					<key>Comment</key>
 					<string>MacPeet - alc892 for MSI GL73-8RD</string>
 					<key>ConfigData</key>
-					<data>
-					AUccIAFHHXABRx4hAUcfAAFHDAIBVxwwAVcd
-					AAFXHhcBVx+QAeccQAHnHXAB5x5FAecfAAEn
-					HFABJx0AAScepgEnH5ABhxxgAYcdcAGHHoEB
-					hx8AAXcccAF3HQABdx4XAXcfkA==
-					</data>
+					<data>AUccIAFHHXABRx4hAUcfAAFHDAIBVxwwAVcdAAFXHhcBVx+QAeccQAHnHXAB5x5FAecfAAEnHFABJx0AAScepgEnH5ABhxxgAYcdcAGHHoEBhx8AAXcccAF3HQABdx4XAXcfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6833,14 +5128,7 @@
 					<key>Comment</key>
 					<string>MacPeet - alc892 for MSI B150M MORTAR - SwitchMode</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBtxwgAbcd
-					QAG3HiEBtx8CAbcMAgFXHDABVx0QAVceAQFX
-					HwEBlxxQAZcdkAGXHoEBlx8CAWcccAFnHWAB
-					Zx4BAWcfAQGHHIABhx2QAYceoAGHH5ABpxyQ
-					AacdMAGnHoEBpx8BAeccsAHnHRAB5x5FAecf
-					AQ==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBtxwgAbcdQAG3HiEBtx8CAbcMAgFXHDABVx0QAVceAQFXHwEBlxxQAZcdkAGXHoEBlx8CAWcccAFnHWABZx4BAWcfAQGHHIABhx2QAYceoAGHH5ABpxyQAacdMAGnHoEBpx8BAeccsAHnHRAB5x5FAecfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6858,14 +5146,7 @@
 					<key>Comment</key>
 					<string>MacPeet - alc892 for MSI B150M MORTAR - ManualMode</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4BAUcfAQFHDAIBtxwgAbcd
-					QAG3HiEBtx8CAbcMAgFXHDABVx0QAVceAQFX
-					HwEBlxxQAZcdkAGXHoEBlx8CAWcccAFnHWAB
-					Zx4BAWcfAQGHHIABhx2QAYceoAGHH5ABpxyQ
-					AacdMAGnHoEBpx8BAeccsAHnHRAB5x5FAecf
-					AQ==
-					</data>
+					<data>AUccEAFHHUABRx4BAUcfAQFHDAIBtxwgAbcdQAG3HiEBtx8CAbcMAgFXHDABVx0QAVceAQFXHwEBlxxQAZcdkAGXHoEBlx8CAWcccAFnHWABZx4BAWcfAQGHHIABhx2QAYceoAGHH5ABpxyQAacdMAGnHoEBpx8BAeccsAHnHRAB5x5FAecfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6883,13 +5164,7 @@
 					<key>Comment</key>
 					<string>ALC892 for Clevo P751DMG by Cryse Hillmes</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUce
-					FwFHH5ABdxxgAXcdEAF3HgEBdx8BAYccgAGH
-					HRABhx6BAYcfAQGnHCABpx0QAacegQGnHwEB
-					txxQAbcdEAG3HiEBtx8BAecccAHnHRAB5x5F
-					AecfAQFHDAI=
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUceFwFHH5ABdxxgAXcdEAF3HgEBdx8BAYccgAGHHRABhx6BAYcfAQGnHCABpx0QAacegQGnHwEBtxxQAbcdEAG3HiEBtx8BAecccAHnHRAB5x5FAecfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6907,17 +5182,7 @@
 					<key>Comment</key>
 					<string>ALC892 for Clevo P65xSE/SA by Derek Zhu</string>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHZEBJx6mAScfkAGHHCABhx1gAYce
-					gQGHHwEBRxwwAUcdAQFHHhcBRx+QAbccQAG3
-					HTABtx4hAbcfAQF3HFABdx1AAXceAQF3HwEB
-					5xxgAecdYQHnHkUB5x8BALcccAC3HREAtx4W
-					ALcfkAFXHPABVx0AAVceAAFXHwQBZxzwAWcd
-					AAFnHgABZx8EAZcc8AGXHQABlx4AAZcfBAGn
-					HPABpx0AAaceAAGnHwQBxxzwAccdAAHHHgAB
-					xx8EAdcc8AHXHQAB1x4AAdcfBAH3HPAB9x0A
-					AfceAAH3HwQBRwwCAbcMAg==
-					</data>
+					<data>ASccEAEnHZEBJx6mAScfkAGHHCABhx1gAYcegQGHHwEBRxwwAUcdAQFHHhcBRx+QAbccQAG3HTABtx4hAbcfAQF3HFABdx1AAXceAQF3HwEB5xxgAecdYQHnHkUB5x8BALcccAC3HREAtx4WALcfkAFXHPABVx0AAVceAAFXHwQBZxzwAWcdAAFnHgABZx8EAZcc8AGXHQABlx4AAZcfBAGnHPABpx0AAaceAAGnHwQBxxzwAccdAAHHHgABxx8EAdcc8AHXHQAB1x4AAdcfBAH3HPAB9x0AAfceAAH3HwQBRwwCAbcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6935,17 +5200,7 @@
 					<key>Comment</key>
 					<string>Custom ALC892 for GIGABYTE B360 M AORUS PRO</string>
 					<key>ConfigData</key>
-					<data>
-					ARccMAEXHQEBFx5DARcfmQEnHPABJx0AASce
-					AAEnH0ABRxxAAUcdQQFHHhEBRx+RAUcMAgFX
-					HPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgAB
-					Zx9AAXccgAF3HSABdx4BAXcfAQGHHBABhx2R
-					AYceoQGHH5EBlxxyAZcdEAGXHqEBlx8CAacc
-					8AGnHQABpx4AAacfQAG3HFIBtx0QAbceIQG3
-					HwIBtwwCAccc8AHHHQABxx4AAccfQAHXHPAB
-					1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9A
-					Afcc8AH3HQAB9x4AAfcfQA==
-					</data>
+					<data>ARccMAEXHQEBFx5DARcfmQEnHPABJx0AASceAAEnH0ABRxxAAUcdQQFHHhEBRx+RAUcMAgFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAXccgAF3HSABdx4BAXcfAQGHHBABhx2RAYceoQGHH5EBlxxyAZcdEAGXHqEBlx8CAacc8AGnHQABpx4AAacfQAG3HFIBtx0QAbceIQG3HwIBtwwCAccc8AHHHQABxx4AAccfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6963,16 +5218,7 @@
 					<key>Comment</key>
 					<string>Custom ALC892 for GA-Z87-HD3 by BIM167</string>
 					<key>ConfigData</key>
-					<data>
-					IRccUCEXHXEhFx5EIRcfASEnHPAhJx0AISce
-					ACEnH0AhRxwQIUcdQCFHHhEhRx+QIVccICFX
-					HRAhVx4BIVcfASFnHDAhZx1gIWceASFnHwEh
-					dxzwIXcdACF3HgAhdx9AIYccYCGHHZAhhx6g
-					IYcfkCGXHIAhlx2QIZcegSGXHwIhpxxwIacd
-					MCGnHoEhpx8BIbccQCG3HUAhtx4hIbcfAiHH
-					HPAhxx0AIcceACHHH0Ah5xzwIecdACHnHgAh
-					5x9AIfcckCH3HXEh9x7EIfcfAQ==
-					</data>
+					<data>IRccUCEXHXEhFx5EIRcfASEnHPAhJx0AISceACEnH0AhRxwQIUcdQCFHHhEhRx+QIVccICFXHRAhVx4BIVcfASFnHDAhZx1gIWceASFnHwEhdxzwIXcdACF3HgAhdx9AIYccYCGHHZAhhx6gIYcfkCGXHIAhlx2QIZcegSGXHwIhpxxwIacdMCGnHoEhpx8BIbccQCG3HUAhtx4hIbcfAiHHHPAhxx0AIcceACHHH0Ah5xzwIecdACHnHgAh5x9AIfcckCH3HXEh9x7EIfcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6986,17 +5232,7 @@
 					<key>Comment</key>
 					<string>Custom ALC892 for HASEE K770e i7 D1 by gitawake</string>
 					<key>ConfigData</key>
-					<data>
-					ARcc8AEXHQABFx4AARcfQAEnHFABJx0BASce
-					pgEnH5ABRxwQAUcdAQFHHhcBRx+QAUcMAgFX
-					HPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgAB
-					Zx9AAXccIAF3HRABdx4BAXcfAQGHHGABhx0Q
-					AYcegQGHHwEBlxzwAZcdAAGXHgABlx9AAacc
-					UAGnHRABpx6BAacfAQG3HDABtx0QAbceIQG3
-					HwEBtwwCAccc8AHHHQABxx4AAccfQAHXHPAB
-					1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9A
-					Afcc8AH3HQAB9x4AAfcfQA==
-					</data>
+					<data>ARcc8AEXHQABFx4AARcfQAEnHFABJx0BAScepgEnH5ABRxwQAUcdAQFHHhcBRx+QAUcMAgFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAXccIAF3HRABdx4BAXcfAQGHHGABhx0QAYcegQGHHwEBlxzwAZcdAAGXHgABlx9AAaccUAGnHRABpx6BAacfAQG3HDABtx0QAbceIQG3HwEBtwwCAccc8AHHHQABxx4AAccfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7010,12 +5246,7 @@
 					<key>Comment</key>
 					<string>ALC892 with working SPDIF</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
-					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
-					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
-					5xyQAecd4AHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7029,12 +5260,7 @@
 					<key>Comment</key>
 					<string>Custom ALC892 DNS P150EM by Constanta</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHHABhx2QAYce
-					gQGHHwEBlxxgAZcdAQGXHqABlx+QAaccgAGn
-					HTABpx6BAacfAQG3HCABtx1AAbceIQG3HwEB
-					5xyQAecd4AHnHkUB5x8B
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHHABhx2QAYcegQGHHwEBlxxgAZcdAQGXHqABlx+QAaccgAGnHTABpx6BAacfAQG3HCABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7048,15 +5274,7 @@
 					<key>Comment</key>
 					<string>ALC898, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
-					ECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3
-					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
-					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
-					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
-					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
-					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7070,15 +5288,7 @@
 					<key>Comment</key>
 					<string>ALC898, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcd
-					ACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
-					HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEh
-					hx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0Q
-					IaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
-					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
-					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcdACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEhhx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0QIaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7092,15 +5302,7 @@
 					<key>Comment</key>
 					<string>ALC898, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
-					ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3
-					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
-					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7114,12 +5316,7 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
-					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
-					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
-					5xyQAecd4AHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7137,14 +5334,7 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7162,17 +5352,7 @@
 					<key>Comment</key>
 					<string>Custom ALC898 by Irving23 for MSI GT72S 6QF-065CN</string>
 					<key>ConfigData</key>
-					<data>
-					ARcc8AEXHQABFx4AARcfQAEnHBABJx0BASce
-					oAEnH5ABRxzwAUcdAAFHHgABRx9AAVcc8AFX
-					HQABVx4AAVcfQAFnHPABZx0AAWceAAFnH0AB
-					dxxgAXcdEAF3HgEBdx8BAYccEAGHHRABhx6h
-					AYcfAQGXHEABlx0BAZceFwGXH5ABpxwgAacd
-					EAGnHoEBpx8BAbccQAG3HQEBtx4XAbcfkAHH
-					HPABxx0AAcceAAHHH0AB1xzwAdcdAAHXHgAB
-					1x9AAecccAHnHREB5x5FAecfAQH3HPAB9x0A
-					AfceAAH3H0ABRwwC
-					</data>
+					<data>ARcc8AEXHQABFx4AARcfQAEnHBABJx0BASceoAEnH5ABRxzwAUcdAAFHHgABRx9AAVcc8AFXHQABVx4AAVcfQAFnHPABZx0AAWceAAFnH0ABdxxgAXcdEAF3HgEBdx8BAYccEAGHHRABhx6hAYcfAQGXHEABlx0BAZceFwGXH5ABpxwgAacdEAGnHoEBpx8BAbccQAG3HQEBtx4XAbcfkAHHHPABxx0AAcceAAHHH0AB1xzwAdcdAAHXHgAB1x9AAecccAHnHREB5x5FAecfAQH3HPAB9x0AAfceAAH3H0ABRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7190,11 +5370,7 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>
-					AaccEAGnHQABpx4XAacfkAHnHCAB5x0QAece
-					RgHnHwEBhxwwAYcdEAGHHoEBhx8BASccQAEn
-					HQABJx6gAScfkA==
-					</data>
+					<data>AaccEAGnHQABpx4XAacfkAHnHCAB5x0QAeceRgHnHwEBhxwwAYcdEAGHHoEBhx8BASccQAEnHQABJx6gAScfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7208,15 +5384,7 @@
 					<key>Comment</key>
 					<string>ALC898, Toleda</string>
 					<key>ConfigData</key>
-					<data>
-					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
-					ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3
-					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
-					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
-					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
-					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
-					HPAhFx0AIRceACEXH0A=
-					</data>
+					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7230,13 +5398,7 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>
-					ARcc8AEXHQABFx4AARcfQAEnHFABJx0BASce
-					pgEnH5ABRxwQAUcdAQFHHhcBRx+QAXccIAF3
-					HRABdx4BAXcfAQGHHEABhx0QAYcegQGHHwEB
-					1xzwAdcdAAHXHgAB1x9AAeccMAHnHREB5x5E
-					AecfAQFHDAI=
-					</data>
+					<data>ARcc8AEXHQABFx4AARcfQAEnHFABJx0BAScepgEnH5ABRxwQAUcdAQFHHhcBRx+QAXccIAF3HRABdx4BAXcfAQGHHEABhx0QAYcegQGHHwEB1xzwAdcdAAHXHgAB1x9AAeccMAHnHREB5x5EAecfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7254,13 +5416,7 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>
-					ARcc8AEXHQABFx4AARcfQAEnHFABJx0BASce
-					pgEnH5ABRxwQAUcdAQFHHhcBRx+QAXccIAF3
-					HRABdx4BAXcfAQGHHEABhx0QAYcegQGHHwEB
-					pxxgAacdEAGnHoEBpx8BAdcc8AHXHQAB1x4A
-					AdcfQAHnHDAB5x0RAeceRAHnHwEBRwwC
-					</data>
+					<data>ARcc8AEXHQABFx4AARcfQAEnHFABJx0BAScepgEnH5ABRxwQAUcdAQFHHhcBRx+QAXccIAF3HRABdx4BAXcfAQGHHEABhx0QAYcegQGHHwEBpxxgAacdEAGnHoEBpx8BAdcc8AHXHQAB1x4AAdcfQAHnHDAB5x0RAeceRAHnHwEBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7278,13 +5434,7 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6gAScfmQGHHCABhx0QAYce
-					gQGHHwIBVxwwAVcdAQFXHhMBVx+ZAaccMQGn
-					HQEBpx4TAacfmQG3HDIBtx0BAbceEwG3H5kB
-					twwCAUccQAFHHRABRx4hAUcfAgFHDAIB5xxQ
-					AecdEQHnHkUB5x8C
-					</data>
+					<data>ASccEAEnHQEBJx6gAScfmQGHHCABhx0QAYcegQGHHwIBVxwwAVcdAQFXHhMBVx+ZAaccMQGnHQEBpx4TAacfmQG3HDIBtx0BAbceEwG3H5kBtwwCAUccQAFHHRABRx4hAUcfAgFHDAIB5xxQAecdEQHnHkUB5x8C</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7302,17 +5452,7 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>
-					ARcc8AEXHQABFx4AARcfQAEnHBABJx0BASce
-					oAEnH5ABRxxQAUcdQAFHHiEBRx8BAUcMAgFX
-					HEABVx0BAVceEAFXH5ABZxzwAWcdAAFnHgAB
-					Zx9AAXcc8AF3HQABdx4AAXcfQAGHHCABhx2Q
-					AYcegQGHHwEBlxzwAZcdAAGXHgABlx9AAacc
-					8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3
-					H0ABxxzwAccdAAHHHgABxx9AAdcc8AHXHQAB
-					1x4AAdcfQAHnHHAB5x1BAeceRQHnHwEB9xzw
-					AfcdAAH3HgAB9x9A
-					</data>
+					<data>ARcc8AEXHQABFx4AARcfQAEnHBABJx0BASceoAEnH5ABRxxQAUcdQAFHHiEBRx8BAUcMAgFXHEABVx0BAVceEAFXH5ABZxzwAWcdAAFnHgABZx9AAXcc8AF3HQABdx4AAXcfQAGHHCABhx2QAYcegQGHHwEBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0ABxxzwAccdAAHHHgABxx9AAdcc8AHXHQAB1x4AAdcfQAHnHHAB5x1BAeceRQHnHwEB9xzwAfcdAAH3HgAB9x9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7330,15 +5470,7 @@
 					<key>Comment</key>
 					<string>ALC898, 4 Line Out by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>
-					AUccAAFHHUABRx4RAUcfkAFXHBABVx0QAVce
-					AQFXHwEBZxwgAWcdYAFnHgEBZx8BAYccMAGH
-					HZABhx6gAYcfkAGnHEABpx0wAacegQGnHwEB
-					lxxQAZcdkAGXHoEBlx8CAbccYAG3HUABtx4h
-					AbcfAgHnHHAB5x1hAeceSwHnHwEBdxyAAXcd
-					IAF3HgEBdx8BAfcc8AH3HQAB9x4AAfcfSQEX
-					HPABFx0AARceAAEXH0k=
-					</data>
+					<data>AUccAAFHHUABRx4RAUcfkAFXHBABVx0QAVceAQFXHwEBZxwgAWcdYAFnHgEBZx8BAYccMAGHHZABhx6gAYcfkAGnHEABpx0wAacegQGnHwEBlxxQAZcdkAGXHoEBlx8CAbccYAG3HUABtx4hAbcfAgHnHHAB5x1hAeceSwHnHwEBdxyAAXcdIAF3HgEBdx8BAfcc8AH3HQAB9x4AAfcfSQEXHPABFx0AARceAAEXH0k=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7352,15 +5484,7 @@
 					<key>Comment</key>
 					<string>toleda - ALC1150 </string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
-					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
-					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
-					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
-					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7378,15 +5502,7 @@
 					<key>Comment</key>
 					<string>toleda - ALC1150 </string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
-					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEB
-					hx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0Q
-					AaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
-					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEBhx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0QAaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7404,15 +5520,7 @@
 					<key>Comment</key>
 					<string>toleda - ALC1150 </string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
-					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
-					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
-					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
-					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7430,12 +5538,7 @@
 					<key>CodecID</key>
 					<integer>283904256</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
-					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
-					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
-					5xyQAecd4AHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7453,14 +5556,7 @@
 					<key>CodecID</key>
 					<integer>283904256</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7478,14 +5574,7 @@
 					<key>CodecID</key>
 					<integer>283904256</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7503,14 +5592,7 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
-					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
-					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
-					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwE=
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwE=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7528,14 +5610,7 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
-					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEB
-					hx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0Q
-					AaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwE=
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEBhx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0QAaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwE=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7553,15 +5628,7 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
-					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
-					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
-					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
-					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7579,12 +5646,7 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
-					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
-					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
-					5xyQAecd4AHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7602,14 +5664,7 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7627,13 +5682,7 @@
 					<key>CodecName</key>
 					<string>Custom Realtek ALC1220 by truesoldier</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAG3HCABtx1AAbce
-					IQG3HwIB5xwwAecdIAHnHksB5x8BAYccQAGH
-					HZABhx6gAYcfkAGXHFABlx2QAZcegQGXHwIB
-					VxxwAVcdEAFXHgEBVx8BAWccgAFnHWABZx4B
-					AWcfAQGnHKABpx0wAacegQGnHwE=
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAG3HCABtx1AAbceIQG3HwIB5xwwAecdIAHnHksB5x8BAYccQAGHHZABhx6gAYcfkAGXHFABlx2QAZcegQGXHwIBVxxwAVcdEAFXHgEBVx8BAWccgAFnHWABZx4BAWcfAQGnHKABpx0wAacegQGnHwE=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7647,12 +5696,7 @@
 					<key>CodecName</key>
 					<string>MacPeet - ALC1220 for Clevo P950HR</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHRABRx4hAUcfAQFHDAIBJxwwAScd
-					AAEnHqYBJx+ZAYccQAGHHRABhx6BAYcfAQG3
-					HGABtx0AAbceFwG3H5kBtwwCAecccAHnHRAB
-					5x5EAecfAQ==
-					</data>
+					<data>AUccEAFHHRABRx4hAUcfAQFHDAIBJxwwAScdAAEnHqYBJx+ZAYccQAGHHRABhx6BAYcfAQG3HGABtx0AAbceFwG3H5kBtwwCAecccAHnHRAB5x5EAecfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7666,12 +5710,7 @@
 					<key>CodecName</key>
 					<string>fleaplus - ALC1220 for MSI WT75</string>
 					<key>ConfigData</key>
-					<data>
-					AbccIAG3HQEBtx4XAbcfkAG3DAIBhxxAAYcd
-					EAGHHqEBhx8BAZccQQGXHRQBlx6BAZcfAQGn
-					HE8Bpx0QAacegQGnHwEBJxxQAScdAQEnHmAB
-					Jx+Q
-					</data>
+					<data>AbccIAG3HQEBtx4XAbcfkAG3DAIBhxxAAYcdEAGHHqEBhx8BAZccQQGXHRQBlx6BAZcfAQGnHE8Bpx0QAacegQGnHwEBJxxQAScdAQEnHmABJx+Q</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7689,14 +5728,7 @@
 					<key>CodecName</key>
 					<string>MacPeet - ALC1220 for Gigabyte Z390</string>
 					<key>ConfigData</key>
-					<data>
-					AeccMAHnHSAB5x5FAecfAQGHHEABhx2QAYce
-					oQGHH5EBlxxQAZcdkAGXHoEBlx8CAUccYAFH
-					HUABRx4hAUcfAgFHDAIBVxxwAVcdEAFXHgEB
-					Vx8BAWccgAFnHWABZx4BAWcfAQGnHJABpx0w
-					AacegQGnHwEBtxygAbcdQAG3HhEBtx+RAbcM
-					Ag==
-					</data>
+					<data>AeccMAHnHSAB5x5FAecfAQGHHEABhx2QAYceoQGHH5EBlxxQAZcdkAGXHoEBlx8CAUccYAFHHUABRx4hAUcfAgFHDAIBVxxwAVcdEAFXHgEBVx8BAWccgAFnHWABZx4BAWcfAQGnHJABpx0wAacegQGnHwEBtxygAbcdQAG3HhEBtx+RAbcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7714,12 +5746,7 @@
 					<key>CodecName</key>
 					<string>ALC1220 for MSI GE63 Raider RGB 8RF</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQEnHCABJx0BASce
-					oAEnH5ABlxwwAZcdEAGXHoEBlx8CAbccgAG3
-					HUABtx4hAbcfAQHnHJAB5x3gAeceRQHnHwEB
-					RwwC
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQEnHCABJx0BASceoAEnH5ABlxwwAZcdEAGXHoEBlx8CAbccgAG3HUABtx4hAbcfAQHnHJAB5x3gAeceRQHnHwEBRwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7737,15 +5764,7 @@
 					<key>CodecName</key>
 					<string>lostwolf - ALC1220 for Gigabyte Z370-HD3P</string>
 					<key>ConfigData</key>
-					<data>
-					AScc8AEnHQABJx4AAScfQAFHHBABRx1AAUce
-					EQFHHwEBRwwCAVccIAFXHRABVx4BAVcfAQFn
-					HDABZx1gAWceAQFnHwEBdxxAAXcdIAF3HgEB
-					dx8BAYccUAGHHZABhx6gAYcfkQGXHGABlx2Q
-					AZcegAGXHwIBpxxwAacdMAGnHoEBpx8BAbcc
-					gAG3HUABtx4hAbcfAgG3DAIB1xzwAdcdAAHX
-					HgAB1x9AAecckAHnHQAB5x5DAecfmQ==
-					</data>
+					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx1AAUceEQFHHwEBRwwCAVccIAFXHRABVx4BAVcfAQFnHDABZx1gAWceAQFnHwEBdxxAAXcdIAF3HgEBdx8BAYccUAGHHZABhx6gAYcfkQGXHGABlx2QAZcegAGXHwIBpxxwAacdMAGnHoEBpx8BAbccgAG3HUABtx4hAbcfAgG3DAIB1xzwAdcdAAHXHgAB1x9AAecckAHnHQAB5x5DAecfmQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7763,14 +5782,7 @@
 					<key>CodecName</key>
 					<string>MacPeet- ALC1220 for Z390 Aorus Ultra - Output SP/HP Manualmode </string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
-					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
-					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
-					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwE=
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwE=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7788,14 +5800,7 @@
 					<key>CodecName</key>
 					<string>MacPeet- ALC1220 for Z390 Aorus Ultra - Output SP/HP SwitchMode</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
-					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
-					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
-					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwE=
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwE=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7813,14 +5818,7 @@
 					<key>CodecName</key>
 					<string>MacPeet- ALC1220 for Z370 AORUS Gaming 7 - Output SP/HP SwitchMode</string>
 					<key>ConfigData</key>
-					<data>
-					AeccMAHnHSAB5x5FAecfAQGHHEABhx2QAYce
-					oQGHH5ABlxxQAZcdkAGXHoEBlx8CAUccYAFH
-					HUABRx4hAUcfAgFHDAIBVxxwAVcdEAFXHgEB
-					Vx8BAWccgAFnHWABZx4BAWcfAQGnHJABpx0w
-					AacegQGnHwEBtxygAbcdQAG3HhEBtx+QAbcM
-					Ag==
-					</data>
+					<data>AeccMAHnHSAB5x5FAecfAQGHHEABhx2QAYceoQGHH5ABlxxQAZcdkAGXHoEBlx8CAUccYAFHHUABRx4hAUcfAgFHDAIBVxxwAVcdEAFXHgEBVx8BAWccgAFnHWABZx4BAWcfAQGnHJABpx0wAacegQGnHwEBtxygAbcdQAG3HhEBtx+QAbcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7838,11 +5836,7 @@
 					<key>CodecName</key>
 					<string>Custom ALC1220 for MSI P65 Creator by CleverCoder</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHRABRx4RAUcfAAFHDAIBtxwgAbcd
-					AAG3HhcBtx+QAbcMAgGXHDABlx0QAZcegQGX
-					HwABJxxAAScdAAEnHqYBJx+Q
-					</data>
+					<data>AUccEAFHHRABRx4RAUcfAAFHDAIBtxwgAbcdAAG3HhcBtx+QAbcMAgGXHDABlx0QAZcegQGXHwABJxxAAScdAAEnHqYBJx+Q</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7860,11 +5854,7 @@
 					<key>CodecName</key>
 					<string>MiBook 2019 by Dynamix1997</string>
 					<key>ConfigData</key>
-					<data>
-					AaccEAGnHQEBpx4QAacfkAFHHCABRx0QAUce
-					IQFHHwMBRwwCASccMAEnHQEBJx6mAScfkAGH
-					HEABhx0QAYcegQGHHwM=
-					</data>
+					<data>AaccEAGnHQEBpx4QAacfkAFHHCABRx0QAUceIQFHHwMBRwwCASccMAEnHQEBJx6mAScfkAGHHEABhx0QAYcegQGHHwM=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7880,14 +5870,7 @@
 					<key>CodecName</key>
 					<string>toleda -  Realtek ALCS1200A</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXcc8AF3
-					HQABdx4AAXcfQAGHHEABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAaccUAGnHTABpx6B
-					AacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecd
-					YQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXcc8AF3HQABdx4AAXcfQAGHHEABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAaccUAGnHTABpx6BAacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecdYQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7903,14 +5886,7 @@
 					<key>CodecName</key>
 					<string>toleda -  Realtek ALCS1200A</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFXHPABVx0AAVce
-					AAFXH0ABZxzwAWcdAAFnHgABZx9AAXcc8AF3
-					HQABdx4AAXcfQAGHHEABhx1gAYceAQGHHwEB
-					lxxgAZcdkAGXHqABlx+QAaccUAGnHRABpx4B
-					AacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecd
-					YQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAXcc8AF3HQABdx4AAXcfQAGHHEABhx1gAYceAQGHHwEBlxxgAZcdkAGXHqABlx+QAaccUAGnHRABpx4BAacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecdYQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7926,14 +5902,7 @@
 					<key>CodecName</key>
 					<string>toleda -  Realtek ALCS1200A</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFXHPABVx0AAVce
-					AAFXH0ABZxzwAWcdAAFnHgABZx9AAXcc8AF3
-					HQABdx4AAXcfQAGHHEABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAaccUAGnHTABpx6B
-					AacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecd
-					YQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAXcc8AF3HQABdx4AAXcfQAGHHEABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAaccUAGnHTABpx6BAacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecdYQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7951,15 +5920,7 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
-					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
-					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
-					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
-					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7977,15 +5938,7 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
-					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEB
-					hx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0Q
-					AaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
-					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEBhx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0QAaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8003,15 +5956,7 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
-					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
-					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
-					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
-					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
-					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
-					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8029,12 +5974,7 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
-					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
-					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
-					5xyQAecd4AHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8052,14 +5992,7 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
-					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
-					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
-					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
-					YAHnHkUB5x8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8075,14 +6008,9 @@
 					<key>CodecID</key>
 					<integer>283906408</integer>
 					<key>CodecName</key>
-					<string>Realtek ALC S1220A Kushamot for Asus Z270G mb (based on Mirone's layout 7)</string>
+					<string>Realtek ALC S1220A Kushamot for Asus Z270G mb (based on Mirone&apos;s layout 7)</string>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHUABRx4RAUcfAQFXHFABVx0QAVce
-					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAYccYAGH
-					HZABhx6gAYcfkAGXHHABlx2QAZcegQGXHwEB
-					txwgAbcdQAG3HiEBtx8BAUcMAg==
-					</data>
+					<data>AUccEAFHHUABRx4RAUcfAQFXHFABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAYccYAGHHZABhx6gAYcfkAGXHHABlx2QAZcegQGXHwEBtxwgAbcdQAG3HiEBtx8BAUcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8136,11 +6064,7 @@
 					<key>CodecID</key>
 					<integer>351346546</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
-					oAGnH5ABlxwwAZcdEAGXHosBlx8BAWccQAFn
-					HRABZx4rAWcfAQF3DAIBZwwC
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAaceoAGnH5ABlxwwAZcdEAGXHosBlx8BAWccQAFnHRABZx4rAWcfAQF3DAIBZwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8154,11 +6078,7 @@
 					<key>CodecID</key>
 					<integer>351346546</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
-					oAGnH5ABlxwwAZcdEAGXHosBlx8BAWccQAFn
-					HRABZx4rAWcfAQF3DAIBZwwCAZcHJAGnByQ=
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAaceoAGnH5ABlxwwAZcdEAGXHosBlx8BAWccQAFnHRABZx4rAWcfAQF3DAIBZwwCAZcHJAGnByQ=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8176,11 +6096,7 @@
 					<key>CodecID</key>
 					<integer>351346566</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkQF3DAIBpxwgAacd
-					AAGnHqYBpx+QAZccMAGXHRABlx6BAZcfAAFn
-					HEABZx0QAWceIQFnHwABZwwC
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkQF3DAIBpxwgAacdAAGnHqYBpx+QAZccMAGXHRABlx6BAZcfAAFnHEABZx0QAWceIQFnHwABZwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8198,11 +6114,7 @@
 					<key>CodecID</key>
 					<integer>351346646</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccQAFnHRABZx4hAWcfBAGXHDABlx0QAZce
-					gQGXHwQBpxwgAacdAQGnHqABpx+QAdccEAHX
-					HQEB1x4XAdcfkAFnDAIB1wwC
-					</data>
+					<data>AWccQAFnHRABZx4hAWcfBAGXHDABlx0QAZcegQGXHwQBpxwgAacdAQGnHqABpx+QAdccEAHXHQEB1x4XAdcfkAFnDAIB1wwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8216,11 +6128,7 @@
 					<key>CodecID</key>
 					<integer>351346646</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccQAFnHRABZx4hAWcfBAGXHDABlx0QAZce
-					gQGXHwQBpxwgAacdAQGnHqABpx+QAXccEAF3
-					HQEBdx4XAXcfkAFnDAIBdwwC
-					</data>
+					<data>AWccQAFnHRABZx4hAWcfBAGXHDABlx0QAZcegQGXHwQBpxwgAacdAQGnHqABpx+QAXccEAF3HQEBdx4XAXcfkAFnDAIBdwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8234,11 +6142,7 @@
 					<key>CodecID</key>
 					<integer>351346696</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
-					oAGnH5ABlxwwAZcdEAGXHosBlx8BAdccQAHX
-					HRAB1x4rAdcfAQF3DAIB1wwC
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAaceoAGnH5ABlxwwAZcdEAGXHosBlx8BAdccQAHXHRAB1x4rAdcfAQF3DAIB1wwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8252,11 +6156,7 @@
 					<key>CodecID</key>
 					<integer>351346696</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkAF3DAIBpxwgAacd
-					AAGnHqYBpx+QAZccMAGXHRABlx6BAZcfAAHX
-					HEAB1x0QAdceIQHXHwAB1wwC
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkAF3DAIBpxwgAacdAAGnHqYBpx+QAZccMAGXHRABlx6BAZcfAAHXHEAB1x0QAdceIQHXHwAB1wwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8274,11 +6174,7 @@
 					<key>CodecID</key>
 					<integer>351346696</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccIAF3HQEBdx4XAXcfkAGXHDABlx0QAZce
-					gQGXHwEBpxxAAacdAQGnHqABpx+QAWccEAFn
-					HRABZx4hAWcfAQFnDAIBdwwC
-					</data>
+					<data>AXccIAF3HQEBdx4XAXcfkAGXHDABlx0QAZcegQGXHwEBpxxAAacdAQGnHqABpx+QAWccEAFnHRABZx4hAWcfAQFnDAIBdwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8296,11 +6192,7 @@
 					<key>CodecID</key>
 					<integer>351346696</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccUAFnHRABZx4hAWcfAQFnDAIBdxxAAXcd
-					AQF3HhcBdx+RAXcMAgGXHHABlx0QAZcegQGX
-					HwEBpxwQAacdAQGnHqYBpx+R
-					</data>
+					<data>AWccUAFnHRABZx4hAWcfAQFnDAIBdxxAAXcdAQF3HhcBdx+RAXcMAgGXHHABlx0QAZcegQGXHwEBpxwQAacdAQGnHqYBpx+R</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8318,15 +6210,7 @@
 					<key>CodecID</key>
 					<integer>351346896</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccEAFnHRABZx4hAWcfBAF3HPABdx0AAXce
-					AAF3H0ABhxzwAYcdAAGHHgABhx9AAZccIAGX
-					HRABlx6BAZcfBAGnHDABpx0BAacepgGnH5AB
-					1xxAAdcdAQHXHhcB1x+ZAecc8AHnHQAB5x4A
-					AecfQAH3HPAB9x0AAfceAAH3H0ACFxzwAhcd
-					AAIXHgACFx9AAmcc8AJnHQACZx4AAmcfQAJ3
-					HPACdx0AAnceAAJ3H0ABZwwCAdcMAg==
-					</data>
+					<data>AWccEAFnHRABZx4hAWcfBAF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAZccIAGXHRABlx6BAZcfBAGnHDABpx0BAacepgGnH5AB1xxAAdcdAQHXHhcB1x+ZAecc8AHnHQAB5x4AAecfQAH3HPAB9x0AAfceAAH3H0ACFxzwAhcdAAIXHgACFx9AAmcc8AJnHQACZx4AAmcfQAJ3HPACdx0AAnceAAJ3H0ABZwwCAdcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8340,13 +6224,7 @@
 					<key>CodecID</key>
 					<integer>351359057</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccQAFnHUABZx4hAWcfAQF3HPABdx0AAXce
-					AAF3H0ABhxwwAYcdMAGHHoEBhx8BAZcc8AGX
-					HQABlx4AAZcfQAGnHBABpx0BAaceFwGnH5AB
-					txzwAbcdAAG3HgABtx9AAccc8AHHHQABxx4A
-					AccfQAHXHCAB1x0BAdceoAHXH5A=
-					</data>
+					<data>AWccQAFnHUABZx4hAWcfAQF3HPABdx0AAXceAAF3H0ABhxwwAYcdMAGHHoEBhx8BAZcc8AGXHQABlx4AAZcfQAGnHBABpx0BAaceFwGnH5ABtxzwAbcdAAG3HgABtx9AAccc8AHHHQABxx4AAccfQAHXHCAB1x0BAdceoAHXH5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8360,14 +6238,7 @@
 					<key>CodecID</key>
 					<integer>351359079</integer>
 					<key>ConfigData</key>
-					<data>
-					AZcc8AGXHUABlx4hAZcfBAGnHPABpx2QAace
-					oQGnHwQBtxzwAbcdAQG3HgABtx9AAccc8AHH
-					HQEBxx4AAccfQAHXHPAB1x0BAdceAAHXH0AB
-					5xzwAecdAQHnHqcB5x+VAfcc8AH3HQEB9x4X
-					AfcfkgIHHPACBx0RAgceRQIHHwQCJxzwAicd
-					AQInHgACJx9AAjcc8AI3HQECNx4AAjcfQA==
-					</data>
+					<data>AZcc8AGXHUABlx4hAZcfBAGnHPABpx2QAaceoQGnHwQBtxzwAbcdAQG3HgABtx9AAccc8AHHHQEBxx4AAccfQAHXHPAB1x0BAdceAAHXH0AB5xzwAecdAQHnHqcB5x+VAfcc8AH3HQEB9x4XAfcfkgIHHPACBx0RAgceRQIHHwQCJxzwAicdAQInHgACJx9AAjcc8AI3HQECNx4AAjcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8381,14 +6252,7 @@
 					<key>CodecID</key>
 					<integer>351359081</integer>
 					<key>ConfigData</key>
-					<data>
-					AZccEAGXHRABlx4gAZcfAAGnHCABpx0AAace
-					AAGnH0ABtxwwAbcdEAG3HoABtx8AAcccUAHH
-					HQABxx4AAccfQAHXHGAB1x0AAdceAAHXH0AB
-					5xxgAecdAAHnHgAB5x9AAfcccAH3HQAB9x4Q
-					AfcfkAIHHIACBx0AAgceAAIHH0ACJxyAAicd
-					AAInHgACJx9AAjcckAI3HQACNx6gAjcfkA==
-					</data>
+					<data>AZccEAGXHRABlx4gAZcfAAGnHCABpx0AAaceAAGnH0ABtxwwAbcdEAG3HoABtx8AAcccUAHHHQABxx4AAccfQAHXHGAB1x0AAdceAAHXH0AB5xxgAecdAAHnHgAB5x9AAfcccAH3HQAB9x4QAfcfkAIHHIACBx0AAgceAAIHH0ACJxyAAicdAAInHgACJx9AAjcckAI3HQACNx6gAjcfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8402,14 +6266,7 @@
 					<key>CodecID</key>
 					<integer>351359081</integer>
 					<key>ConfigData</key>
-					<data>
-					AZccEAGXHRABlx4gAZcfAAGnHCABpx0wAace
-					gQGnHwEBtxwwAbcdAAG3HgABtx9AAcccUAHH
-					HQABxx4AAccfQAHXHGAB1x0AAdceAAHXH0AB
-					5xxgAecdAAHnHgAB5x9AAfcccAH3HQAB9x4Q
-					AfcfkAIHHIACBx0AAgceAAIHH0ACJxyAAicd
-					AAInHgACJx9AAjcckAI3HQECNx6gAjcfkA==
-					</data>
+					<data>AZccEAGXHRABlx4gAZcfAAGnHCABpx0wAacegQGnHwEBtxwwAbcdAAG3HgABtx9AAcccUAHHHQABxx4AAccfQAHXHGAB1x0AAdceAAHXH0AB5xxgAecdAAHnHgAB5x9AAfcccAH3HQAB9x4QAfcfkAIHHIACBx0AAgceAAIHH0ACJxyAAicdAAInHgACJx9AAjcckAI3HQECNx6gAjcfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8423,11 +6280,7 @@
 					<key>CodecID</key>
 					<integer>351359084</integer>
 					<key>ConfigData</key>
-					<data>
-					AZccQAGXHRABlx4hAZcfAgG3HDABtx0QAbce
-					owG3H5kCNxxQAjcdAQI3HqECNx+SAfccEAH3
-					HQEB9x4TAfcfmQ==
-					</data>
+					<data>AZccQAGXHRABlx4hAZcfAgG3HDABtx0QAbceowG3H5kCNxxQAjcdAQI3HqECNx+SAfccEAH3HQEB9x4TAfcfmQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8441,11 +6294,7 @@
 					<key>CodecID</key>
 					<integer>351359086</integer>
 					<key>ConfigData</key>
-					<data>
-					AZccQAGXHRABlx4hAZcfAAGnHDABpx0QAace
-					gQGnHwABtxwgAbcdAAG3HqcBtx+QAfccEAH3
-					HQAB9x4XAfcfkQ==
-					</data>
+					<data>AZccQAGXHRABlx4hAZcfAAGnHDABpx0QAacegQGnHwABtxwgAbcdAAG3HqcBtx+QAfccEAH3HQAB9x4XAfcfkQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8459,14 +6308,7 @@
 					<key>Comment</key>
 					<string>CX20590 Custom for Lenovo Yoga 13 by usr-sse2</string>
 					<key>ConfigData</key>
-					<data>
-					AZccMAGXHUABlx4rAZcfDgH3HCAB9x0BAfce
-					EAH3H5ACNxwQAjcdAQI3HqACNx+QAaccQAGn
-					HRABpx6BAacfAQG3HPABtx0AAbceAAG3H0AB
-					xxzwAccdAAHHHgABxx9AAdcc8AHXHQAB1x4A
-					AdcfQAHnHPAB5x0AAeceAAHnH0ACBxzwAgcd
-					AAIHHgACBx9AAicc8AInHQACJx4AAicfQA==
-					</data>
+					<data>AZccMAGXHUABlx4rAZcfDgH3HCAB9x0BAfceEAH3H5ACNxwQAjcdAQI3HqACNx+QAaccQAGnHRABpx6BAacfAQG3HPABtx0AAbceAAG3H0ABxxzwAccdAAHHHgABxx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACBxzwAgcdAAIHHgACBx9AAicc8AInHQACJx4AAicfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8480,14 +6322,7 @@
 					<key>Comment</key>
 					<string>CX20590 for Lenovo T420 by tluck (Additional ports for use with a Docking Station)</string>
 					<key>ConfigData</key>
-					<data>
-					AFccAABXHQAAVx5WAFcfGABnHBAAZx0AAGce
-					VgBnHxgAdxwgAHcdAAB3HlYAdx8YAZccMAGX
-					HRABlx4hAZcfBAGnHEABpx2QAaceoQGnH2EB
-					txxQAbcdEAG3HoEBtx8BAcccYAHHHUABxx4h
-					AccfYQH3HHAB9x0BAfceFwH3H5kCNxyAAjcd
-					AQI3HqYCNx+ZAbcMAg==
-					</data>
+					<data>AFccAABXHQAAVx5WAFcfGABnHBAAZx0AAGceVgBnHxgAdxwgAHcdAAB3HlYAdx8YAZccMAGXHRABlx4hAZcfBAGnHEABpx2QAaceoQGnH2EBtxxQAbcdEAG3HoEBtx8BAcccYAHHHUABxx4hAccfYQH3HHAB9x0BAfceFwH3H5kCNxyAAjcdAQI3HqYCNx+ZAbcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8505,14 +6340,7 @@
 					<key>Comment</key>
 					<string>CX20590 for Lenovo T420 by tluck (Standard Laptop)</string>
 					<key>ConfigData</key>
-					<data>
-					AFccAABXHQAAVx5WAFcfGABnHBAAZx0AAGce
-					VgBnHxgAdxwgAHcdAAB3HlYAdx8YAZccMAGX
-					HRABlx4hAZcfBAGnHEABpx2QAaceoQGnH2EB
-					txxQAbcdEAG3HoEBtx8BAcccYAHHHUABxx4h
-					AccfYQH3HHAB9x0BAfceFwH3H5kCNxyAAjcd
-					AQI3HqYCNx+ZAbcMAg==
-					</data>
+					<data>AFccAABXHQAAVx5WAFcfGABnHBAAZx0AAGceVgBnHxgAdxwgAHcdAAB3HlYAdx8YAZccMAGXHRABlx4hAZcfBAGnHEABpx2QAaceoQGnH2EBtxxQAbcdEAG3HoEBtx8BAcccYAHHHUABxx4hAccfYQH3HHAB9x0BAfceFwH3H5kCNxyAAjcdAQI3HqYCNx+ZAbcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8530,11 +6358,7 @@
 					<key>Comment</key>
 					<string>CX20641 - MacPeet - Dell OptiPlex 3010 - ManualMode</string>
 					<key>ConfigData</key>
-					<data>
-					IcccECHHHUAhxx4BIccfASGnHCAhpx2QIace
-					gSGnHwIhtxwwIbcdMCG3HoEhtx8BIZccQCGX
-					HUAhlx4hIZcfAg==
-					</data>
+					<data>IcccECHHHUAhxx4BIccfASGnHCAhpx2QIacegSGnHwIhtxwwIbcdMCG3HoEhtx8BIZccQCGXHUAhlx4hIZcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8548,11 +6372,7 @@
 					<key>Comment</key>
 					<string>CX20641 - MacPeet - Dell OptiPlex 3010 - SwitchMode</string>
 					<key>ConfigData</key>
-					<data>
-					IcccECHHHUAhxx4RIccfkCGnHCAhpx2QIace
-					gSGnHwIhtxwwIbcdMCG3HoEhtx8BIZccQCGX
-					HUAhlx4hIZcfAg==
-					</data>
+					<data>IcccECHHHUAhxx4RIccfkCGnHCAhpx2QIacegSGnHwIhtxwwIbcdMCG3HoEhtx8BIZccQCGXHUAhlx4hIZcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8566,11 +6386,7 @@
 					<key>Comment</key>
 					<string>CX20642 - MacPeet - Fujitsu ESPRIMO E910 E90+ Desktop - ManualMode</string>
 					<key>ConfigData</key>
-					<data>
-					IcccECHHHUAhxx4BIccfASGnHCAhpx0QIace
-					gSGnHwIhlxxAIZcdECGXHiEhlx8CIdccUCHX
-					HTAh1x6BIdcfAQ==
-					</data>
+					<data>IcccECHHHUAhxx4BIccfASGnHCAhpx0QIacegSGnHwIhlxxAIZcdECGXHiEhlx8CIdccUCHXHTAh1x6BIdcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8584,11 +6400,7 @@
 					<key>Comment</key>
 					<string>CX20642 - MacPeet - Fujitsu ESPRIMO E910 E90+ Desktop - SwitchMode</string>
 					<key>ConfigData</key>
-					<data>
-					IcccECHHHUAhxx4RIccfkCGnHCAhpx0QIace
-					oSGnH5IhlxxAIZcdECGXHiEhlx8CIdccUCHX
-					HTAh1x6BIdcfAQ==
-					</data>
+					<data>IcccECHHHUAhxx4RIccfkCGnHCAhpx0QIaceoSGnH5IhlxxAIZcdECGXHiEhlx8CIdccUCHXHTAh1x6BIdcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8602,11 +6414,7 @@
 					<key>Comment</key>
 					<string>Custom for Dell Vostro 3x60 by vusun123</string>
 					<key>ConfigData</key>
-					<data>
-					AfccEAH3HQAB9x4XAfcfkQGnHDABpx0QAace
-					gQGnHwkBlxxAAZcdEAGXHiEBlx8AAjccIAI3
-					HQECNx6nAjcfkAG3DAIB1wwC
-					</data>
+					<data>AfccEAH3HQAB9x4XAfcfkQGnHDABpx0QAacegQGnHwkBlxxAAZcdEAGXHiEBlx8AAjccIAI3HQECNx6nAjcfkAG3DAIB1wwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8620,11 +6428,7 @@
 					<key>CodecID</key>
 					<integer>351359218</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4WAXcfkQGnHCABpx0AAace
-					pgGnH5ABlxwwAZcdEAGXHoEBlx8CAWccQAFn
-					HRABZx4hAWcfAg==
-					</data>
+					<data>AXccEAF3HQABdx4WAXcfkQGnHCABpx0AAacepgGnH5ABlxwwAZcdEAGXHoEBlx8CAWccQAFnHRABZx4hAWcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8638,11 +6442,7 @@
 					<key>CodecID</key>
 					<integer>351359220</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccEAFnHRABZx4hAWcfAgF3HCABdx0AAXce
-					FwF3H5EBlxwwAZcdEAGXHoEBlx8CAaccQAGn
-					HQABpx6mAacfkA==
-					</data>
+					<data>AWccEAFnHRABZx4hAWcfAgF3HCABdx0AAXceFwF3H5EBlxwwAZcdEAGXHoEBlx8CAaccQAGnHQABpx6mAacfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8656,11 +6456,7 @@
 					<key>CodecID</key>
 					<integer>351359220</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQEBdx4XAXcfkQGnHCABpx0BAace
-					oAGnH5UBlxwwAZcdEAGXHosBlx8EAdccQAHX
-					HRAB1x4rAdcfBA==
-					</data>
+					<data>AXccEAF3HQEBdx4XAXcfkQGnHCABpx0BAaceoAGnH5UBlxwwAZcdEAGXHosBlx8EAdccQAHXHRAB1x4rAdcfBA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8674,11 +6470,7 @@
 					<key>CodecID</key>
 					<integer>351359247</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccEAFnHUABZx4hAWcfAQF3HCABdx0AAXce
-					FwF3H5ABhxwwAYcdkAGHHoEBhx8BAaccQAGn
-					HQABpx6gAacfkA==
-					</data>
+					<data>AWccEAFnHUABZx4hAWcfAQF3HCABdx0AAXceFwF3H5ABhxwwAYcdkAGHHoEBhx8BAaccQAGnHQABpx6gAacfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8690,11 +6482,7 @@
 					<key>CodecID</key>
 					<integer>351359247</integer>
 					<key>ConfigData</key>
-					<data>
-					AZcHJAGnByQBZxxAAWcdEAFnHiEBZx8EAXcc
-					EAF3HQEBdx4XAXcfkAGXHDABlx0QAZcegQGX
-					HwQBpxwgAacdAQGnHqABpx+Q
-					</data>
+					<data>AZcHJAGnByQBZxxAAWcdEAFnHiEBZx8EAXccEAF3HQEBdx4XAXcfkAGXHDABlx0QAZcegQGXHwQBpxwgAacdAQGnHqABpx+Q</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8710,15 +6498,15 @@
 					<key>CodecID</key>
 					<integer>351359247</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccQAFnHRABZx4hAWcfBAF3HBABdx0BAXce
-					FwF3H5ABlxwwAZcdEAGXHoEBlx8EAaccIAGn
-					HQEBpx6gAacfkA==
-					</data>
+					<data>AWccQAFnHRABZx4hAWcfBAF3HBABdx0BAXceFwF3H5ABlxwwAZcdEAGXHoEBlx8EAZcHJAGnHCABpx0BAaceoAGnH5ABpwck</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
 					<integer>28</integer>
+					<key>WakeConfigData</key>
+					<data>AZcHJAGnByQ=</data>
+					<key>WakeVerbReinit</key>
+					<true/>
 				</dict>
 				<dict>
 					<key>AFGLowPowerState</key>
@@ -8728,11 +6516,7 @@
 					<key>CodecID</key>
 					<integer>351359249</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccEAFnHUABZx4hAWcfAgF3HCABdx0AAXce
-					FwF3H5ABlxwwAZcdkAGXHoEBlx8CAaccQAGn
-					HQABpx6gAacfkA==
-					</data>
+					<data>AWccEAFnHUABZx4hAWcfAgF3HCABdx0AAXceFwF3H5ABlxwwAZcdkAGXHoEBlx8CAaccQAGnHQABpx6gAacfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8746,11 +6530,7 @@
 					<key>CodecID</key>
 					<integer>351359249</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQEBdx4XAXcfkAFnHBMBZx0QAWce
-					IQFnHwMBlxwwAZcdEAGXHoEBlx8DAaccQAGn
-					HQEBpx6gAacfkA==
-					</data>
+					<data>AXccEAF3HQEBdx4XAXcfkAFnHBMBZx0QAWceIQFnHwMBlxwwAZcdEAGXHoEBlx8DAaccQAGnHQEBpx6gAacfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8764,11 +6544,7 @@
 					<key>CodecID</key>
 					<integer>351359249</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
-					pgGnH5ABlxwwAZcdEAGXHoEBlx8AAWccQAFn
-					HRABZx4hAWcfAA==
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAacepgGnH5ABlxwwAZcdEAGXHoEBlx8AAWccQAFnHRABZx4hAWcfAA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8782,11 +6558,7 @@
 					<key>CodecID</key>
 					<integer>351359249</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccIAF3HQEBdx4XAXcfkAGXHDABlx0QAZce
-					gQGXHwMBpxxAAacdAQGnHqABpx+QAdccEAHX
-					HRAB1x4hAdcfAw==
-					</data>
+					<data>AXccIAF3HQEBdx4XAXcfkAGXHDABlx0QAZcegQGXHwMBpxxAAacdAQGnHqABpx+QAdccEAHXHRAB1x4hAdcfAw==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8800,11 +6572,7 @@
 					<key>CodecID</key>
 					<integer>351359251</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
-					pgGnH5UBhxwwAYcdkAGHHosBhx8CAWccQAFn
-					HUABZx4rAWcfAg==
-					</data>
+					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAacepgGnH5UBhxwwAYcdkAGHHosBhx8CAWccQAFnHUABZx4rAWcfAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8818,11 +6586,7 @@
 					<key>CodecID</key>
 					<integer>351359252</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccEAFnHUABZx4hAWcfAQF3HCABdx0AAXce
-					EwF3H5ABhxwwAYcdkAGHHqEBhx8CAaccQAGn
-					HQABpx6mAacfkA==
-					</data>
+					<data>AWccEAFnHUABZx4hAWcfAQF3HCABdx0AAXceEwF3H5ABhxwwAYcdkAGHHqEBhx8CAaccQAGnHQABpx6mAacfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8836,11 +6600,7 @@
 					<key>CodecID</key>
 					<integer>351359252</integer>
 					<key>ConfigData</key>
-					<data>
-					AXccEAF3HQEBdx4XAXcfkAGnHCABpx0BAace
-					oAGnH5ABlxwwAZcdEAGXHosBlx8CAWccQAFn
-					HRABZx4rAWcfAgGHHPABhx0AAYceAAGHH0A=
-					</data>
+					<data>AXccEAF3HQEBdx4XAXcfkAGnHCABpx0BAaceoAGnH5ABlxwwAZcdEAGXHosBlx8CAWccQAFnHRABZx4rAWcfAgGHHPABhx0AAYceAAGHH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8854,11 +6614,7 @@
 					<key>CodecID</key>
 					<integer>351359253</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccEAFnHQABZx4hAWcfAQF3HCABdx0AAXce
-					EwF3H5ABhxwwAYcdAAGHHoEBhx8CAaccUAGn
-					HQABpx6gAacfkA==
-					</data>
+					<data>AWccEAFnHQABZx4hAWcfAQF3HCABdx0AAXceEwF3H5ABhxwwAYcdAAGHHoEBhx8CAaccUAGnHQABpx6gAacfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8886,11 +6642,7 @@
 					<key>CodecID</key>
 					<integer>287143633</integer>
 					<key>ConfigData</key>
-					<data>
-					ANccAADXHQAA1x4XANcfmQEXHCABFx0AARce
-					oAEXH5kAtxwwALcdQAC3HiEAtx8BAMccQADH
-					HRAAxx6AAMcfAQ==
-					</data>
+					<data>ANccAADXHQAA1x4XANcfmQEXHCABFx0AARceoAEXH5kAtxwwALcdQAC3HiEAtx8BAMccQADHHRAAxx6AAMcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8918,11 +6670,7 @@
 					<key>CodecID</key>
 					<integer>287143573</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccEACnHRAApx4hAKcfAgCnDAIAtxwgALcd
-					EAC3HqEAtx8CALcMAgDXHDAA1x0BANceFwDX
-					H5AA1wwCAOccQADnHQEA5x6gAOcfkA==
-					</data>
+					<data>AKccEACnHRAApx4hAKcfAgCnDAIAtxwgALcdEAC3HqEAtx8CALcMAgDXHDAA1x0BANceFwDXH5AA1wwCAOccQADnHQEA5x6gAOcfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8936,11 +6684,7 @@
 					<key>CodecID</key>
 					<integer>287143667</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccEACnHUAApx4hAKcfAgC3HCAAtx1AALce
-					EwC3H5AAxxwwAMcdkADHHoEAxx8CAOccQADn
-					HZAA5x6gAOcfkA==
-					</data>
+					<data>AKccEACnHUAApx4hAKcfAgC3HCAAtx1AALceEwC3H5AAxxwwAMcdkADHHoEAxx8CAOccQADnHZAA5x6gAOcfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8954,16 +6698,7 @@
 					<key>CodecID</key>
 					<integer>287143602</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccEACnHRAApx4hAKcfAAC3HCAAtx0QALce
-					gQC3HwIAxxwwAMcdAADHHvAAxx9AANccQADX
-					HQAA1x4XANcfkADnHFAA5x0QAOceoQDnHyAB
-					RxxgAUcdAAFHHvABRx9AAYcccAGHHQABhx6g
-					AYcfkAGXHIABlx0AAZce8AGXH0AB5xyQAecd
-					EAHnHkYB5x8BAfccoAH3HQAB9x7wAfcfQAIH
-					HLACBx0AAgce8AIHH0ACdxzAAncdAAJ3HvAC
-					dx9A
-					</data>
+					<data>AKccEACnHRAApx4hAKcfAAC3HCAAtx0QALcegQC3HwIAxxwwAMcdAADHHvAAxx9AANccQADXHQAA1x4XANcfkADnHFAA5x0QAOceoQDnHyABRxxgAUcdAAFHHvABRx9AAYcccAGHHQABhx6gAYcfkAGXHIABlx0AAZce8AGXH0AB5xyQAecdEAHnHkYB5x8BAfccoAH3HQAB9x7wAfcfQAIHHLACBx0AAgce8AIHH0ACdxzAAncdAAJ3HvACdx9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8977,11 +6712,7 @@
 					<key>CodecID</key>
 					<integer>287143541</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccEACnHRAApx4hAKcfAwDXHCAA1x0BANce
-					FwDXH5AA5xwwAOcdEADnHoEA5x8DAPccQAD3
-					HRAA9x4BAPcfAwE3HFABNx0BATceoAE3H5A=
-					</data>
+					<data>AKccEACnHRAApx4hAKcfAwDXHCAA1x0BANceFwDXH5AA5xwwAOcdEADnHoEA5x8DAPccQAD3HRAA9x4BAPcfAwE3HFABNx0BATceoAE3H5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -8995,11 +6726,7 @@
 					<key>CodecID</key>
 					<integer>287143541</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccEACnHRAApx4hAKcfBADHHCAAxx0QAMce
-					gQDHHwQA5xwwAOcdAQDnHhcA5x+QATccQAE3
-					HQEBNx6gATcfkA==
-					</data>
+					<data>AKccEACnHRAApx4hAKcfBADHHCAAxx0QAMcegQDHHwQA5xwwAOcdAQDnHhcA5x+QATccQAE3HQEBNx6gATcfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9013,11 +6740,7 @@
 					<key>CodecID</key>
 					<integer>287143637</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccIACnHRAApx6BAKcfAgC3HDAAtx0QALce
-					IQC3HwIA1xxAANcdAADXHhcA1x+QARccUAEX
-					HQABFx6gARcfkA==
-					</data>
+					<data>AKccIACnHRAApx6BAKcfAgC3HDAAtx0QALceIQC3HwIA1xxAANcdAADXHhcA1x+QARccUAEXHQABFx6gARcfkA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9031,15 +6754,7 @@
 					<key>CodecID</key>
 					<integer>287143637</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccIACnHRAApx6BAKcfBACnDAIAtxwwALcd
-					EAC3HiEAtx8EALcMAgDHHPAAxx0AAMceAADH
-					H0AA1xxAANcdAQDXHhcA1x+QANcMAgDnHPAA
-					5x0AAOceAADnH0AA9xzwAPcdAAD3HgAA9x9A
-					AQcc8AEHHQABBx4AAQcfQAEXHFABFx0BARce
-					oAEXH5AB9xzwAfcdAAH3HgAB9x9AAgcc8AIH
-					HQACBx4AAgcfQA==
-					</data>
+					<data>AKccIACnHRAApx6BAKcfBACnDAIAtxwwALcdEAC3HiEAtx8EALcMAgDHHPAAxx0AAMceAADHH0AA1xxAANcdAQDXHhcA1x+QANcMAgDnHPAA5x0AAOceAADnH0AA9xzwAPcdAAD3HgAA9x9AAQcc8AEHHQABBx4AAQcfQAEXHFABFx0BARceoAEXH5AB9xzwAfcdAAH3HgAB9x9AAgcc8AIHHQACBx4AAgcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9053,14 +6768,7 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccIACnHRAApx6hAKcfAQC3HBAAtx0QALce
-					IQC3HwEA1xwwANcdAADXHhcA1x+QAOcc8ADn
-					HQAA5x4AAOcfQAD3HEAA9x0AAPceAAD3H0AB
-					BxxQAQcdAAEHHgABBx9AARccYAEXHQABFx6j
-					ARcf0AH3HHAB9x0AAfceAAH3H0ACBxyAAgcd
-					AAIHHgACBx9A
-					</data>
+					<data>AKccIACnHRAApx6hAKcfAQC3HBAAtx0QALceIQC3HwEA1xwwANcdAADXHhcA1x+QAOcc8ADnHQAA5x4AAOcfQAD3HEAA9x0AAPceAAD3H0ABBxxQAQcdAAEHHgABBx9AARccYAEXHQABFx6jARcf0AH3HHAB9x0AAfceAAH3H0ACBxyAAgcdAAIHHgACBx9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9074,15 +6782,7 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHRABJx6BAScfBAFHHCABRx0BAUce
-					FwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGH
-					HPABhx0AAYceAAGHH0ABlxzwAZcdAAGXHgAB
-					lx9AAacc8AGnHQABpx4AAacfQAG3HDABtx0B
-					AbceoAG3H5AB1xzwAdcdAAHXHgAB1x9AAecc
-					8AHnHQAB5x4AAecfQAIXHEACFx0QAhceIQIX
-					HwMCFwwC
-					</data>
+					<data>ASccEAEnHRABJx6BAScfBAFHHCABRx0BAUceFwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGHHPABhx0AAYceAAGHH0ABlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HDABtx0BAbceoAG3H5AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHEACFx0QAhceIQIXHwMCFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9110,14 +6810,7 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccIACnHRAApx6BAKcfAQC3HFAAtx0QALce
-					IQC3HwEA1xwwANcdAQDXHhAA1x+QAOcc8ADn
-					HQAA5x4AAOcfQAD3HPAA9x0AAPceAAD3H0AB
-					BxzwAQcdAAEHHgABBx9AARccEAEXHQEBFx6g
-					ARcfkAH3HPAB9x0AAfceAAH3H0ACBxzwAgcd
-					AAIHHgACBx9AAMcc8ADHHQAAxx4AAMcfQA==
-					</data>
+					<data>AKccIACnHRAApx6BAKcfAQC3HFAAtx0QALceIQC3HwEA1xwwANcdAQDXHhAA1x+QAOcc8ADnHQAA5x4AAOcfQAD3HPAA9x0AAPceAAD3H0ABBxzwAQcdAAEHHgABBx9AARccEAEXHQEBFx6gARcfkAH3HPAB9x0AAfceAAH3H0ACBxzwAgcdAAIHHgACBx9AAMcc8ADHHQAAxx4AAMcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9131,14 +6824,7 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>
-					AMccIADHHRAAxx6BAMcfAQC3HFAAtx0QALce
-					IQC3HwEA9xwwAPcdAQD3HhAA9x+QAOcc8ADn
-					HQAA5x4AAOcfQADXHPAA1x0AANceAADXH0AB
-					BxzwAQcdAAEHHgABBx9AARccEAEXHQEBFx6g
-					ARcfkAH3HPAB9x0AAfceAAH3H0ACBxzwAgcd
-					AAIHHgACBx9AAKcc8ACnHQAApx4AAKcfQA==
-					</data>
+					<data>AMccIADHHRAAxx6BAMcfAQC3HFAAtx0QALceIQC3HwEA9xwwAPcdAQD3HhAA9x+QAOcc8ADnHQAA5x4AAOcfQADXHPAA1x0AANceAADXH0ABBxzwAQcdAAEHHgABBx9AARccEAEXHQEBFx6gARcfkAH3HPAB9x0AAfceAAH3H0ACBxzwAgcdAAIHHgACBx9AAKcc8ACnHQAApx4AAKcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9152,11 +6838,7 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>
-					ARccAAEXHQEBFx6jARcfmQDHHBAAxx0QAMce
-					gQDHHwEA1xwgANcdAQDXHhMA1x+ZALccMAC3
-					HRAAtx4hALcfAQFHDAI=
-					</data>
+					<data>ARccAAEXHQEBFx6jARcfmQDHHBAAxx0QAMcegQDHHwEA1xwgANcdAQDXHhMA1x+ZALccMAC3HRAAtx4hALcfAQFHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9170,14 +6852,7 @@
 					<key>CodecID</key>
 					<integer>287143432</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccEACnHRAApx4hAKcfAQC3HCAAtx0QALce
-					gQC3HwEAxxwwAMcdEADHHqAAxx+QANccQADX
-					HQAA1x4RANcfkADnHFAA5x0AAOce8ADnH0AB
-					RxxgAUcdAAFHHvABRx9AAYcccAGHHQABhx7w
-					AYcfQAHnHIAB5x0AAece8AHnH0AB9xyQAfcd
-					AAH3HvAB9x9AAgccoAIHHQACBx7wAgcfQA==
-					</data>
+					<data>AKccEACnHRAApx4hAKcfAQC3HCAAtx0QALcegQC3HwEAxxwwAMcdEADHHqAAxx+QANccQADXHQAA1x4RANcfkADnHFAA5x0AAOce8ADnH0ABRxxgAUcdAAFHHvABRx9AAYcccAGHHQABhx7wAYcfQAHnHIAB5x0AAece8AHnH0AB9xyQAfcdAAH3HvAB9x9AAgccoAIHHQACBx7wAgcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9191,11 +6866,7 @@
 					<key>CodecID</key>
 					<integer>287143427</integer>
 					<key>ConfigData</key>
-					<data>
-					ALccEAC3HRAAtx6gALcfkADXHCAA1x0AANce
-					FwDXH5AA9xwwAPcdQAD3HiEA9x8BAYccQAGH
-					HZABhx6BAYcfAQ==
-					</data>
+					<data>ALccEAC3HRAAtx6gALcfkADXHCAA1x0AANceFwDXH5AA9xwwAPcdQAD3HiEA9x8BAYccQAGHHZABhx6BAYcfAQ==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9209,10 +6880,7 @@
 					<key>CodecID</key>
 					<integer>287143427</integer>
 					<key>ConfigData</key>
-					<data>
-					ALccAAC3HQAAtx6nALcfmQDXHBAA1x0AANce
-					FwDXH5kA9xwgAPcdQAD3HiEA9x8B
-					</data>
+					<data>ALccAAC3HQAAtx6nALcfmQDXHBAA1x0AANceFwDXH5kA9xwgAPcdQAD3HiEA9x8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9226,13 +6894,7 @@
 					<key>CodecID</key>
 					<integer>287143655</integer>
 					<key>ConfigData</key>
-					<data>
-					ALccEAC3HRAAtx4hALcfAACnHCAApx0QAKce
-					gQCnHwABFxwwARcdkAEXHqABFx+QANccQADX
-					HQAA1x4XANcfkADnHFAA5x0QAOceAQDnHyAA
-					9xxgAPcdEAD3HqEA9x8gAQcc8AEHHQABBx4A
-					AQcfQA==
-					</data>
+					<data>ALccEAC3HRAAtx4hALcfAACnHCAApx0QAKcegQCnHwABFxwwARcdkAEXHqABFx+QANccQADXHQAA1x4XANcfkADnHFAA5x0QAOceAQDnHyAA9xxgAPcdEAD3HqEA9x8gAQcc8AEHHQABBx4AAQcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9246,11 +6908,7 @@
 					<key>CodecID</key>
 					<integer>287143655</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccIACnHRAApx6BAKcfAAC3HBAAtx0QALce
-					IQC3HwAA1xxAANcdAADXHhcA1x+QARccMAEX
-					HQABFx6gARcf0A==
-					</data>
+					<data>AKccIACnHRAApx6BAKcfAAC3HBAAtx0QALceIQC3HwAA1xxAANcdAADXHhcA1x+QARccMAEXHQABFx6gARcf0A==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9264,14 +6922,7 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALce
-					IQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEX
-					HQABFx6gARcfmQDXHEAA1x0BANceFwDXH5kA
-					5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4A
-					AQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcd
-					AAIHHgACBx9J
-					</data>
+					<data>AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALceIQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEXHQABFx6gARcfmQDXHEAA1x0BANceFwDXH5kA5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4AAQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcdAAIHHgACBx9J</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9285,14 +6936,7 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALce
-					IQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEX
-					HQABFx6gARcfmQD3HEAA9x0BAPceFwD3H5kA
-					5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4A
-					AQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcd
-					AAIHHgACBx9J
-					</data>
+					<data>AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALceIQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEXHQABFx6gARcfmQD3HEAA9x0BAPceFwD3H5kA5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4AAQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcdAAIHHgACBx9J</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9306,11 +6950,7 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>
-					ALccEAC3HRAAtx4hALcfAAC3DAIAxxwgAMcd
-					EADHHoEAxx8AARccMAEXHQABFx6jARcfmQDX
-					HEAA1x0AANceEADXH5AA1wwC
-					</data>
+					<data>ALccEAC3HRAAtx4hALcfAAC3DAIAxxwgAMcdEADHHoEAxx8AARccMAEXHQABFx6jARcfmQDXHEAA1x0AANceEADXH5AA1wwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9324,14 +6964,7 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>
-					ALccIAC3HRAAtx4hALcfAwD3HDIA9x0BAPce
-					FwD3H5ABFxwQARcdAQEXHqYBFx+XANcc8ADX
-					HQAA1x4AANcfQAEHHPABBx0AAQceAAEHH0AA
-					pxzwAKcdAACnHgAApx9AAMcc8ADHHQAAxx4A
-					AMcfQADnHPAA5x0AAOceAADnH0AB9xzwAfcd
-					AAH3HgAB9x9AAgcc8AIHHQACBx4AAgcfQA==
-					</data>
+					<data>ALccIAC3HRAAtx4hALcfAwD3HDIA9x0BAPceFwD3H5ABFxwQARcdAQEXHqYBFx+XANcc8ADXHQAA1x4AANcfQAEHHPABBx0AAQceAAEHH0AApxzwAKcdAACnHgAApx9AAMcc8ADHHQAAxx4AAMcfQADnHPAA5x0AAOceAADnH0AB9xzwAfcdAAH3HgAB9x9AAgcc8AIHHQACBx4AAgcfQA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9345,14 +6978,7 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALce
-					IQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEX
-					HQABFx6gARcfmQD3HEAA9x0BAPceFwD3H5kA
-					5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4A
-					AQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcd
-					AAIHHgACBx9J
-					</data>
+					<data>AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALceIQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEXHQABFx6gARcfmQD3HEAA9x0BAPceFwD3H5kA5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4AAQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcdAAIHHgACBx9J</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9366,13 +6992,7 @@
 					<key>CodecID</key>
 					<integer>287143647</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccIACnHRAApx6BAKcfAACnDAIAtxwQALcd
-					EAC3HiEAtx8AALcMAgDXHEAA1x0BANceFwDX
-					H5AA1wwCAOccUADnHRAA5x4BAOcfIADnDAIA
-					9xxgAPcdEAD3HoEA9x8gAQcc8AEHHQABBx4A
-					AQcfQAEXHDABFx0BARceoAEXH5A=
-					</data>
+					<data>AKccIACnHRAApx6BAKcfAACnDAIAtxwQALcdEAC3HiEAtx8AALcMAgDXHEAA1x0BANceFwDXH5AA1wwCAOccUADnHRAA5x4BAOcfIADnDAIA9xxgAPcdEAD3HoEA9x8gAQcc8AEHHQABBx4AAQcfQAEXHDABFx0BARceoAEXH5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9386,12 +7006,7 @@
 					<key>CodecID</key>
 					<integer>287143653</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccEACnHZAApx6BAKcfAgC3HCAAtx1AALce
-					IQC3HwIAxxwwAMcdAADHHvAAxx9AANccQADX
-					HQAA1x4TANcf0AD3HFAA9x0AAPce8AD3H0AB
-					FxxgARcdAAEXHqABFx+QANcMAg==
-					</data>
+					<data>AKccEACnHZAApx6BAKcfAgC3HCAAtx1AALceIQC3HwIAxxwwAMcdAADHHvAAxx9AANccQADXHQAA1x4TANcf0AD3HFAA9x0AAPce8AD3H0ABFxxgARcdAAEXHqABFx+QANcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9405,14 +7020,7 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>
-					AKccIACnHRAApx6hAKcfAQC3HBAAtx0QALce
-					IQC3HwEA1xwwANcdAADXHhcA1x+QAOcc8ADn
-					HQAA5x4AAOcfQAD3HEAA9x0AAPceAAD3H0AB
-					BxxQAQcdAAEHHgABBx9AARccYAEXHQABFx6j
-					ARcf0AH3HHAB9x0AAfceAAH3H0ACBxyAAgcd
-					AAIHHgACBx9A
-					</data>
+					<data>AKccIACnHRAApx6hAKcfAQC3HBAAtx0QALceIQC3HwEA1xwwANcdAADXHhcA1x+QAOcc8ADnHQAA5x4AAOcfQAD3HEAA9x0AAPceAAD3H0ABBxxQAQcdAAEHHgABBx9AARccYAEXHQABFx6jARcf0AH3HHAB9x0AAfceAAH3H0ACBxyAAgcdAAIHHgACBx9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9426,13 +7034,7 @@
 					<key>CodecID</key>
 					<integer>2206496400</integer>
 					<key>ConfigData</key>
-					<data>
-					AIcc8ACHHQAAhx4AAIcfQACXHPAAlx0AAJce
-					AACXH0AA1xwQANcdEADXHiEA1x8CAOccIADn
-					HQEA5x4QAOcfkAD3HDAA9x0BAPceoAD3H5AB
-					BxxAAQcdEAEHHoEBBx8CARcc8AEXHQABFx4A
-					ARcfQAEnHPABJx0AASceAAEnH0A=
-					</data>
+					<data>AIcc8ACHHQAAhx4AAIcfQACXHPAAlx0AAJceAACXH0AA1xwQANcdEADXHiEA1x8CAOccIADnHQEA5x4QAOcfkAD3HDAA9x0BAPceoAD3H5ABBxxAAQcdEAEHHoEBBx8CARcc8AEXHQABFx4AARcfQAEnHPABJx0AASceAAEnH0A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9446,11 +7048,7 @@
 					<key>CodecID</key>
 					<integer>2206496354</integer>
 					<key>ConfigData</key>
-					<data>
-					APccEAD3HQEA9x4XAPcfkACnHCAApx1AAKce
-					IQCnHwQBRxw+AUcdkAFHHqABRx+QARccQAEX
-					HREBFx5WARcfGA==
-					</data>
+					<data>APccEAD3HQEA9x4XAPcfkACnHCAApx1AAKceIQCnHwQBRxw+AUcdkAFHHqABRx+QARccQAEXHREBFx5WARcfGA==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9464,11 +7062,7 @@
 					<key>CodecID</key>
 					<integer>285624160</integer>
 					<key>ConfigData</key>
-					<data>
-					AkccEAJHHQACRx4AAkcfAQKHHCAChx1AAoce
-					IQKHHwICtxwwArcdkAK3HoECtx8BAwccQAMH
-					HQADBx6gAwcfkAJHDAI=
-					</data>
+					<data>AkccEAJHHQACRx4AAkcfAQKHHCAChx1AAoceIQKHHwICtxwwArcdkAK3HoECtx8BAwccQAMHHQADBx6gAwcfkAJHDAI=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9482,12 +7076,7 @@
 					<key>CodecID</key>
 					<integer>285639750</integer>
 					<key>ConfigData</key>
-					<data>
-					AkccEAJHHQACRx4TAkcfkAJXHCACVx1AAlce
-					IQJXHwEClxxAApcdAAKXHqAClx+QArccYAK3
-					HZACtx6BArcfAgLXHHAC1x0QAtceRALXHwAC
-					RwwCAlcMAw==
-					</data>
+					<data>AkccEAJHHQACRx4TAkcfkAJXHCACVx1AAlceIQJXHwEClxxAApcdAAKXHqAClx+QArccYAK3HZACtx6BArcfAgLXHHAC1x0QAtceRALXHwACRwwCAlcMAw==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9501,12 +7090,7 @@
 					<key>CodecID</key>
 					<integer>285639750</integer>
 					<key>ConfigData</key>
-					<data>
-					AkccEAJHHQACRx4TAkcfkAJXHCACVx1AAlce
-					IQJXHwEClxxAApcdAAKXHqAClx+QArccYAK3
-					HZACtx6BArcfAgLXHHAC1x0QAtceRALXHwAC
-					RwwCAlcMAw==
-					</data>
+					<data>AkccEAJHHQACRx4TAkcfkAJXHCACVx1AAlceIQJXHwEClxxAApcdAAKXHqAClx+QArccYAK3HZACtx6BArcfAgLXHHAC1x0QAtceRALXHwACRwwCAlcMAw==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9520,11 +7104,7 @@
 					<key>CodecID</key>
 					<integer>285639750</integer>
 					<key>ConfigData</key>
-					<data>
-					AkccQAJHHQACRx4XAkcfkAJHDAICVxxQAlcd
-					EAJXHiECVx8CAlcMAgMHHBADBx0AAwceoAMH
-					H5A=
-					</data>
+					<data>AkccQAJHHQACRx4XAkcfkAJHDAICVxxQAlcdEAJXHiECVx8CAlcMAgMHHBADBx0AAwceoAMHH5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9538,12 +7118,7 @@
 					<key>CodecID</key>
 					<integer>285606977</integer>
 					<key>ConfigData</key>
-					<data>
-					IkccECJHHUAiRx4BIkcfASKHHCAihx1AIoce
-					ISKHHwEilxwwIpcdkCKXHqEilx8CIqccQCKn
-					HTAipx6BIqcfASK3HFAitx2QIrcegSK3HwEi
-					5xxgIucdECLnHkUi5x8A
-					</data>
+					<data>IkccECJHHUAiRx4BIkcfASKHHCAihx1AIoceISKHHwEilxwwIpcdkCKXHqEilx8CIqccQCKnHTAipx6BIqcfASK3HFAitx2QIrcegSK3HwEi5xxgIucdECLnHkUi5x8A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9557,14 +7132,7 @@
 					<key>CodecID</key>
 					<integer>285606977</integer>
 					<key>ConfigData</key>
-					<data>
-					IkccECJHHUAiRx4RIkcfASJXHCAiVx0QIlce
-					ASJXHwEiZxwwImcdYCJnHgEiZx8BInccQCJ3
-					HSAidx4BIncfASKHHFAihx1AIoceISKHHwEi
-					lxxgIpcdkCKXHqEilx8CIqcccCKnHTAipx6B
-					IqcfASK3HIAitx2QIrcegSK3HwEi5xygIucd
-					ECLnHkUi5x8A
-					</data>
+					<data>IkccECJHHUAiRx4RIkcfASJXHCAiVx0QIlceASJXHwEiZxwwImcdYCJnHgEiZx8BInccQCJ3HSAidx4BIncfASKHHFAihx1AIoceISKHHwEilxxgIpcdkCKXHqEilx8CIqcccCKnHTAipx6BIqcfASK3HIAitx2QIrcegSK3HwEi5xygIucdECLnHkUi5x8A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9578,16 +7146,7 @@
 					<key>CodecID</key>
 					<integer>285606977</integer>
 					<key>ConfigData</key>
-					<data>
-					Ihcc8CIXHQAiFx4AIhcfQCJHHBAiRx1AIkce
-					ESJHHwEiRwwCIlcc8CJXHQAiVx4AIlcfQCJn
-					HPAiZx0AImceACJnH0AidxzwIncdACJ3HgAi
-					dx9AIoccICKHHUAihx4hIocfASKXHEAilx2Q
-					IpceoCKXH5AilwchIqccgCKnHTAipx6BIqcf
-					ASK3HPAitx0AIrceACK3H0AixxzwIscdACLH
-					HgAixx9AItcc8CLXHQAi1x4AItcfQCLnHJAi
-					5x1hIuceSyLnHwEi9xzwIvcdACL3HgAi9x9A
-					</data>
+					<data>Ihcc8CIXHQAiFx4AIhcfQCJHHBAiRx1AIkceESJHHwEiRwwCIlcc8CJXHQAiVx4AIlcfQCJnHPAiZx0AImceACJnH0AidxzwIncdACJ3HgAidx9AIoccICKHHUAihx4hIocfASKXHEAilx2QIpceoCKXH5AilwchIqccgCKnHTAipx6BIqcfASK3HPAitx0AIrceACK3H0AixxzwIscdACLHHgAixx9AItcc8CLXHQAi1x4AItcfQCLnHJAi5x1hIuceSyLnHwEi9xzwIvcdACL3HgAi9x9A</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9601,11 +7160,7 @@
 					<key>CodecID</key>
 					<integer>351359253</integer>
 					<key>ConfigData</key>
-					<data>
-					AWccQAFnHRABZx4hAWcfAQF3HBABdx0BAXce
-					FwF3H5ABhxzwAYcdAAGHHgABhx9AAZccMAGX
-					HRABlx6BAZcfAQGnHCABpx0BAacepwGnH5A=
-					</data>
+					<data>AWccQAFnHRABZx4hAWcfAQF3HBABdx0BAXceFwF3H5ABhxzwAYcdAAGHHgABhx9AAZccMAGXHRABlx6BAZcfAQGnHCABpx0BAacepwGnH5A=</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9619,11 +7174,7 @@
 					<key>CodecID</key>
 					<integer>283902597</integer>
 					<key>ConfigData</key>
-					<data>
-					AUccEAFHHQEBRx4XAUcfmQFHDAICFxwgAhcd
-					EAIXHiECFx8EAhcMAgEnHDABJx0BAScepgEn
-					H5kBlxxAAZcdEAGXHoEBlx8B
-					</data>
+					<data>AUccEAFHHQEBRx4XAUcfmQFHDAICFxwgAhcdEAIXHiECFx8EAhcMAgEnHDABJx0BAScepgEnH5kBlxxAAZcdEAGXHoEBlx8B</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -9641,11 +7192,7 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>
-					ASccEAEnHQEBJx6mAScfmQFHHEABRx0BAUce
-					FwFHH5kBlxwgAZcdEAGXHoEBlx8AAhccUAIX
-					HRACFx4hAhcfAAFHDAICFwwC
-					</data>
+					<data>ASccEAEnHQEBJx6mAScfmQFHHEABRx0BAUceFwFHH5kBlxwgAZcdEAGXHoEBlx8AAhccUAIXHRACFx4hAhcfAAFHDAICFwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -36,7 +36,12 @@
 					<key>Comment</key>
 					<string>frankiezdh - Conexant CX20632 for HP ProDesk 480 G4</string>
 					<key>ConfigData</key>
-					<data>AZccUAGXHRABlx4hAZcfAQGnHBABpx0QAaceoQGnHwEBxxyAAccdQQHHHgEBxx8BAdccIAHXHTEB1x6BAdcfAQHXDAIB9xxAAfcdAQH3Hh8B9x+R</data>
+					<data>
+					AZccUAGXHRABlx4hAZcfAQGnHBABpx0QAace
+					oQGnHwEBxxyAAccdQQHHHgEBxx8BAdccIAHX
+					HTEB1x6BAdcfAQHXDAIB9xxAAfcdAQH3Hh8B
+					9x+R
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -54,7 +59,15 @@
 					<key>Comment</key>
 					<string>CX20632 by Daniel</string>
 					<key>ConfigData</key>
-					<data>AfccEAH3HQEB9x4XAfcfkgH3DAIBpxwgAacdEAGnHosBpx8CAZccQAGXHRABlx4rAZcfAgHHHNABxx1AAcceIQHHHwIBhxzwAYcdAAGHHgABhx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAgcc8AIHHQACBx4AAgcfQAIXHPACFx0AAhceAAIXH0ACZxzwAmcdAAJnHgACZx9A</data>
+					<data>
+					AfccEAH3HQEB9x4XAfcfkgH3DAIBpxwgAacd
+					EAGnHosBpx8CAZccQAGXHRABlx4rAZcfAgHH
+					HNABxx1AAcceIQHHHwIBhxzwAYcdAAGHHgAB
+					hx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0A
+					AdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAgcc
+					8AIHHQACBx4AAgcfQAIXHPACFx0AAhceAAIX
+					H0ACZxzwAmcdAAJnHgACZx9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -72,7 +85,11 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>ABcWHwAXFx4BVwoBAVcXDQFXGCQAtwwAANcc8ADXHQAA1x4AANcfQAEXBwQBJx+QATceAAE3H0ABhx4AAYcfQA==</data>
+					<data>
+					ABcWHwAXFx4BVwoBAVcXDQFXGCQAtwwAANcc
+					8ADXHQAA1x4AANcfQAEXBwQBJx+QATceAAE3
+					H0ABhx4AAYcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -86,7 +103,11 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>AVcKAQFnAwAAtxwQALcdQQC3HhAAtx+QANcc8ADXHQAA1x4AANcfQAD3HCABFxxAARcegQEnHDABJx+Q</data>
+					<data>
+					AVcKAQFnAwAAtxwQALcdQQC3HhAAtx+QANcc
+					8ADXHQAA1x4AANcfQAD3HCABFxxAARcegQEn
+					HDABJx+Q
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -100,7 +121,11 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>ABcXHgAXFRABVwoBAScIgQFnCIABVxcNAVcYJADXHPAA1x0AANceAADXH0ABBx4hAScfkAE3HPABNx0AATceAAE3H0A=</data>
+					<data>
+					ABcXHgAXFRABVwoBAScIgQFnCIABVxcNAVcY
+					JADXHPAA1x0AANceAADXH0ABBx4hAScfkAE3
+					HPABNx0AATceAAE3H0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -114,7 +139,11 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>ABcXHgAXFRQBVwoBAScIgQFnCIABVxcNAVcYJADXHPAA1x0AANceAADXH0AA5xzwAOcdAADnHgAA5x9AAQceAQEnH5A=</data>
+					<data>
+					ABcXHgAXFRQBVwoBAScIgQFnCIABVxcNAVcY
+					JADXHPAA1x0AANceAADXH0AA5xzwAOcdAADn
+					HgAA5x9AAQceAQEnH5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -128,7 +157,12 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>ABcWHwAXFx4AFxUUAVcKAQEnCIEBZwiAAVcXDQFXGCQA1xzwANcdAADXHgAA1x9AAOcc8ADnHQAA5x4AAOcfQAEHHgEBJx+QATcc8AE3HQABNx4AATcfQAGHHPABhx0AAYceAAGHH0A=</data>
+					<data>
+					ABcWHwAXFx4AFxUUAVcKAQEnCIEBZwiAAVcX
+					DQFXGCQA1xzwANcdAADXHgAA1x9AAOcc8ADn
+					HQAA5x4AAOcfQAEHHgEBJx+QATcc8AE3HQAB
+					Nx4AATcfQAGHHPABhx0AAYceAAGHH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -142,7 +176,11 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>ABcXHgAXFRIBVwoBAScIgQFnCIABVxcNAVcYIQC3HiEA1xzwANcdAADXHgAA1x9AAQceAQEXBwQBJx+Q</data>
+					<data>
+					ABcXHgAXFRIBVwoBAScIgQFnCIABVxcNAVcY
+					IQC3HiEA1xzwANcdAADXHgAA1x9AAQceAQEX
+					BwQBJx+Q
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -156,7 +194,10 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>ABcXHgAXFRABVwoBAScIgQFnCIABVxcNAVcYJADXHPAA1x0AANceAADXH0ABBx4hAScfkA==</data>
+					<data>
+					ABcXHgAXFRABVwoBAScIgQFnCIABVxcNAVcY
+					JADXHPAA1x0AANceAADXH0ABBx4hAScfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -170,7 +211,13 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>IVcKAQC3HBAAtx1AALceAQC3HwEAxxwgAMcdgADHHkUAxx8BANccIADXHUAA1x4BANcfAQD3HDAA9x1AAPceIQD3HwEBBxxAAQcdQAEHHiEBBx8CARccUAEXHUABFx4BARcfAQEnHFABJx2QAScepwEnH5A=</data>
+					<data>
+					IVcKAQC3HBAAtx1AALceAQC3HwEAxxwgAMcd
+					gADHHkUAxx8BANccIADXHUAA1x4BANcfAQD3
+					HDAA9x1AAPceIQD3HwEBBxxAAQcdQAEHHiEB
+					Bx8CARccUAEXHUABFx4BARcfAQEnHFABJx2Q
+					AScepwEnH5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -184,7 +231,10 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>AVcKAQAXFRQBJwiBAWcIgAFXFw0BVxgkIQceAQEnH5A=</data>
+					<data>
+					AVcKAQAXFRQBJwiBAWcIgAFXFw0BVxgkIQce
+					AQEnH5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -198,7 +248,15 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>IVcD8CFXFw0hVxgkIVcPgCC3HCAgtx1AILceASC3HwEgxxxgIMcdICDHHkUgxx8BINcc8CDXHQAg1x4AINcfQCDnHPAg5x0AIOceACDnH0Ag9xwvIPcdQCD3HiEg9x8BIQccMCEHHUAhBx4hIQcfASEXHEAhFx0QIRceASEXHwEhJxwQIScdkSEnHqEhJx+QITcc8CE3HQAhNx4AITcfQCGHHFAhhx1gIYceASGHHwE=</data>
+					<data>
+					IVcD8CFXFw0hVxgkIVcPgCC3HCAgtx1AILce
+					ASC3HwEgxxxgIMcdICDHHkUgxx8BINcc8CDX
+					HQAg1x4AINcfQCDnHPAg5x0AIOceACDnH0Ag
+					9xwvIPcdQCD3HiEg9x8BIQccMCEHHUAhBx4h
+					IQcfASEXHEAhFx0QIRceASEXHwEhJxwQIScd
+					kSEnHqEhJx+QITcc8CE3HQAhNx4AITcfQCGH
+					HFAhhx1gIYceASGHHwE=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -212,7 +270,10 @@
 					<key>CodecID</key>
 					<integer>285343761</integer>
 					<key>ConfigData</key>
-					<data>AVcKAQAXFx8AFxUQAScIgQFnCIABVxcNAVcYJAEnH5A=</data>
+					<data>
+					AVcKAQAXFx8AFxUQAScIgQFnCIABVxcNAVcY
+					JAEnH5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -226,7 +287,11 @@
 					<key>CodecID</key>
 					<integer>269697552</integer>
 					<key>ConfigData</key>
-					<data>AFccEABXHUAAVx4hAFcfAABnHCAAZx0AAGceFwBnH5AAdxwwAHcdkAB3HoEAdx8AAJccQACXHQAAlx6gAJcfkA==</data>
+					<data>
+					AFccEABXHUAAVx4hAFcfAABnHCAAZx0AAGce
+					FwBnH5AAdxwwAHcdkAB3HoEAdx8AAJccQACX
+					HQAAlx6gAJcfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -240,7 +305,11 @@
 					<key>CodecID</key>
 					<integer>269697555</integer>
 					<key>ConfigData</key>
-					<data>AEccEABHHRAARx4hAEcfAABXHCAAVx0AAFceFwBXH5AAZxwwAGcdEABnHoEAZx8AAHccQAB3HQAAdx6gAHcfkABXDAI=</data>
+					<data>
+					AEccEABHHRAARx4hAEcfAABXHCAAVx0AAFce
+					FwBXH5AAZxwwAGcdEABnHoEAZx8AAHccQAB3
+					HQAAdx6gAHcfkABXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -254,7 +323,12 @@
 					<key>CodecID</key>
 					<integer>299112836</integer>
 					<key>ConfigData</key>
-					<data>ARccEAEXHUABFx4hARcfAAFHHCABRx1QAUcegQFHHwABJxwwAScdAAEnHhcBJx+QAScMAgFXHEABVx0AAVcepwFXH5ABxxyAAccdUAHHHoEBxx8BAbccoAG3HRABtx5EAbcfIQ==</data>
+					<data>
+					ARccEAEXHUABFx4hARcfAAFHHCABRx1QAUce
+					gQFHHwABJxwwAScdAAEnHhcBJx+QAScMAgFX
+					HEABVx0AAVcepwFXH5ABxxyAAccdUAHHHoEB
+					xx8BAbccoAG3HRABtx5EAbcfIQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -268,7 +342,11 @@
 					<key>CodecID</key>
 					<integer>299112778</integer>
 					<key>ConfigData</key>
-					<data>ISccECEnHUAhJx4BIScfASFHHCAhRx2QIUceoSFHHwIhVxwwIVcdMCFXHoEhVx8BIRccQCEXHUAhFx4hIRcfAg==</data>
+					<data>
+					ISccECEnHUAhJx4BIScfASFHHCAhRx2QIUce
+					oSFHHwIhVxwwIVcdMCFXHoEhVx8BIRccQCEX
+					HUAhFx4hIRcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -282,7 +360,11 @@
 					<key>CodecID</key>
 					<integer>299112778</integer>
 					<key>ConfigData</key>
-					<data>ISccECEnHUAhJx4RIScfkCFHHCAhRx2QIUceoSFHHwIhVxwwIVcdMCFXHoEhVx8BIRccQCEXHUAhFx4hIRcfAg==</data>
+					<data>
+					ISccECEnHUAhJx4RIScfkCFHHCAhRx2QIUce
+					oSFHHwIhVxwwIVcdMCFXHoEhVx8BIRccQCEX
+					HUAhFx4hIRcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -296,7 +378,13 @@
 					<key>CodecID</key>
 					<integer>299112778</integer>
 					<key>ConfigData</key>
-					<data>ASccAAEnHUABJx4BAScfAQHHHBABxx0wAccegQHHHwEBdxwgAXcdEAF3HqYBdx+5ARccMAEXHUABFx4hARcfAQFnHEABZx1AAWceFwFnH5EBpxxQAacdEAGnHvcBpx9RAbccYAG3HWABtx5EAbcfAQE3HPABNx0QATceHwE3H1E=</data>
+					<data>
+					ASccAAEnHUABJx4BAScfAQHHHBABxx0wAcce
+					gQHHHwEBdxwgAXcdEAF3HqYBdx+5ARccMAEX
+					HUABFx4hARcfAQFnHEABZx1AAWceFwFnH5EB
+					pxxQAacdEAGnHvcBpx9RAbccYAG3HWABtx5E
+					AbcfAQE3HPABNx0QATceHwE3H1E=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -310,7 +398,16 @@
 					<key>CodecID</key>
 					<integer>299112840</integer>
 					<key>ConfigData</key>
-					<data>ARccQAEXHUABFx4hARcfAQEnHAABJx1AASceEQEnHwEBNxzwATcdAAE3HgABNx9AAUccYAFHHZABRx6gAUcfkAFXHIABVx0wAVcegQFXHwEBZxwgAWcdEAFnHgEBZx8BAXccUAF3HZABdx6BAXcfAQGHHPABhx0AAYceAAGHH0ABtxygAbcd8QG3HkUBtx8BAccc8AHHHQABxx4AAccfQAJHHBACRx1gAkceAQJHHwECVxwwAlcdIAJXHgECVx8B</data>
+					<data>
+					ARccQAEXHUABFx4hARcfAQEnHAABJx1AASce
+					EQEnHwEBNxzwATcdAAE3HgABNx9AAUccYAFH
+					HZABRx6gAUcfkAFXHIABVx0wAVcegQFXHwEB
+					ZxwgAWcdEAFnHgEBZx8BAXccUAF3HZABdx6B
+					AXcfAQGHHPABhx0AAYceAAGHH0ABtxygAbcd
+					8QG3HkUBtx8BAccc8AHHHQABxx4AAccfQAJH
+					HBACRx1gAkceAQJHHwECVxwwAlcdIAJXHgEC
+					Vx8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -324,7 +421,12 @@
 					<key>CodecID</key>
 					<integer>299112843</integer>
 					<key>ConfigData</key>
-					<data>ARccEAEXHUABFx4hARcfAQEnHCABJx1AASceAQEnHwEBRxxAAUcdkAFHHqEBRx8BAVccUAFXHTABVx6BAVcfAQF3HHABdx2QAXceoQF3HwEBtxzwAbcd8QG3HkUBtx8B</data>
+					<data>
+					ARccEAEXHUABFx4hARcfAQEnHCABJx1AASce
+					AQEnHwEBRxxAAUcdkAFHHqEBRx8BAVccUAFX
+					HTABVx6BAVcfAQF3HHABdx2QAXceoQF3HwEB
+					txzwAbcd8QG3HkUBtx8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -338,7 +440,14 @@
 					<key>CodecID</key>
 					<integer>299112843</integer>
 					<key>ConfigData</key>
-					<data>ARccEAEXHUABFx4hARcfAQEnHCABJx1AASceEQEnHwEBRxwwAUcdkAFHHqABRx+QAWccQAFnHRABZx4BAWcfAQF3HFABdx2QAXcegQF3HwEBtxxgAbcd8QG3HkUBtx8BAccccAHHHfEBxx7FAccfAQHXHIAB1x3xAdceVgHXHxgCRxyQAkcdYAJHHgECRx8BAlcckAJXHSACVx4BAlcfAQ==</data>
+					<data>
+					ARccEAEXHUABFx4hARcfAQEnHCABJx1AASce
+					EQEnHwEBRxwwAUcdkAFHHqABRx+QAWccQAFn
+					HRABZx4BAWcfAQF3HFABdx2QAXcegQF3HwEB
+					txxgAbcd8QG3HkUBtx8BAccccAHHHfEBxx7F
+					AccfAQHXHIAB1x3xAdceVgHXHxgCRxyQAkcd
+					YAJHHgECRx8BAlcckAJXHSACVx4BAlcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -354,7 +463,14 @@
 					<key>Comment</key>
 					<string>Custom AD1988B by Rodion</string>
 					<key>ConfigData</key>
-					<data>AXccIAF3HZABdx6gAXcfkQFHHCEBRx2QAUcegQFHHwIBJxwQAScdQAEnHhEBJx8BAkccEQJHHWACRx4RAkcfAQFnHBIBZx0QAWceEQFnHwECVxwUAlcdIAJXHhECVx8BAccc8AHHHQABxx4AAccfQAE3HPABNx0AATceAAE3H0ABpxzwAacdAAGnHgABpx9AAYcc8AGHHQABhx4AAYcfQA==</data>
+					<data>
+					AXccIAF3HZABdx6gAXcfkQFHHCEBRx2QAUce
+					gQFHHwIBJxwQAScdQAEnHhEBJx8BAkccEQJH
+					HWACRx4RAkcfAQFnHBIBZx0QAWceEQFnHwEC
+					VxwUAlcdIAJXHhECVx8BAccc8AHHHQABxx4A
+					AccfQAE3HPABNx0AATceAAE3H0ABpxzwAacd
+					AAGnHgABpx9AAYcc8AGHHQABhx4AAYcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -368,7 +484,12 @@
 					<key>CodecID</key>
 					<integer>299145371</integer>
 					<key>ConfigData</key>
-					<data>ARccEAEXHUABFx4hARcfAQEnHCABJx1AASceAQEnHwEBRxxAAUcdkAFHHqEBRx8BAVccUAFXHTABVx6BAVcfAQF3HHABdx2QAXceoQF3HwEBtxzwAbcd8QG3HkUBtx8B</data>
+					<data>
+					ARccEAEXHUABFx4hARcfAQEnHCABJx1AASce
+					AQEnHwEBRxxAAUcdkAFHHqEBRx8BAVccUAFX
+					HTABVx6BAVcfAQF3HHABdx2QAXceoQF3HwEB
+					txzwAbcd8QG3HkUBtx8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -382,7 +503,14 @@
 					<key>CodecID</key>
 					<integer>299145371</integer>
 					<key>ConfigData</key>
-					<data>ARccMAEXHUABFx4hARcfAQEnHBABJx1AASceEQEnHwEBRxxAAUcdkAFHHqABRx+QAWccUAFnHRABZx4BAWcfAQF3HCABdx2QAXcegQF3HwEBtxygAbcd8QG3HkUBtx8BAcccYAHHHfEBxx7FAccfAQHXHLAB1x3xAdceVgHXHxgCRxxwAkcdYAJHHgECRx8BAlccgAJXHSACVx4BAlcfAQ==</data>
+					<data>
+					ARccMAEXHUABFx4hARcfAQEnHBABJx1AASce
+					EQEnHwEBRxxAAUcdkAFHHqABRx+QAWccUAFn
+					HRABZx4BAWcfAQF3HCABdx2QAXcegQF3HwEB
+					txygAbcd8QG3HkUBtx8BAcccYAHHHfEBxx7F
+					AccfAQHXHLAB1x3xAdceVgHXHxgCRxxwAkcd
+					YAJHHgECRx8BAlccgAJXHSACVx4BAlcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -396,7 +524,11 @@
 					<key>CodecID</key>
 					<integer>283902485</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQEBRx4XAUcfmQIXHCACFx0QAhceIQIXHwECFwwCASccMAEnHRgBJx6BAScfAQGXHEABlx0BAZcepgGXH5kBRwwC</data>
+					<data>
+					AUccEAFHHQEBRx4XAUcfmQIXHCACFx0QAhce
+					IQIXHwECFwwCASccMAEnHRgBJx6BAScfAQGX
+					HEABlx0BAZcepgGXH5kBRwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -414,7 +546,12 @@
 					<key>CodecID</key>
 					<integer>283902497</integer>
 					<key>ConfigData</key>
-					<data>AUccIAFHHUABRx4BAUcfAQFHDAIBdxwQAXcdAQF3HhcBdx+QAXcMAgGnHEABpx0QAacegQGnHwIBpwckAbccMAG3HTABtx6BAbcfAQIXHFACFx0QAhceIQIXHwICFwwC</data>
+					<data>
+					AUccIAFHHUABRx4BAUcfAQFHDAIBdxwQAXcd
+					AQF3HhcBdx+QAXcMAgGnHEABpx0QAacegQGn
+					HwIBpwckAbccMAG3HTABtx6BAbcfAQIXHFAC
+					Fx0QAhceIQIXHwICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -432,7 +569,12 @@
 					<key>CodecID</key>
 					<integer>283902497</integer>
 					<key>ConfigData</key>
-					<data>AUccIAFHHUABRx4RAUcfkQFHDAIBpxwwAacdEAGnHoEBpx8CAXccQAF3HQABdx4XAXcfkAG3HFABtx0wAbcegQG3HwECFxxwAhcdEAIXHiECFx8CAhcMAg==</data>
+					<data>
+					AUccIAFHHUABRx4RAUcfkQFHDAIBpxwwAacd
+					EAGnHoEBpx8CAXccQAF3HQABdx4XAXcfkAG3
+					HFABtx0wAbcegQG3HwECFxxwAhcdEAIXHiEC
+					Fx8CAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -450,7 +592,16 @@
 					<key>CodecID</key>
 					<integer>283902501</integer>
 					<key>ConfigData</key>
-					<data>ASccUAEnHQEBJx6mAScftwE3HAABNx0AATceAAE3H0ABRxywAUcdAQFHHhcBRx+QAWcc8AFnHREBZx4RAWcfQQF3HPABdx0RAXceEQF3H0EBhxzwAYcdEQGHHhEBhx9BAZccQAGXHRABlx6BAZcfAQGnHPABpx0RAaceEQGnH0EBtxzwAbcdEQG3HhEBtx9BAdccAQHXHQAB1x5gAdcfQAHnHPAB5x0RAeceEQHnH0ECFxwgAhcdEAIXHiECFx8EAUcMAg==</data>
+					<data>
+					ASccUAEnHQEBJx6mAScftwE3HAABNx0AATce
+					AAE3H0ABRxywAUcdAQFHHhcBRx+QAWcc8AFn
+					HREBZx4RAWcfQQF3HPABdx0RAXceEQF3H0EB
+					hxzwAYcdEQGHHhEBhx9BAZccQAGXHRABlx6B
+					AZcfAQGnHPABpx0RAaceEQGnH0EBtxzwAbcd
+					EQG3HhEBtx9BAdccAQHXHQAB1x5gAdcfQAHn
+					HPAB5x0RAeceEQHnH0ECFxwgAhcdEAIXHiEC
+					Fx8EAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -468,7 +619,11 @@
 					<key>CodecID</key>
 					<integer>283902501</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6gAScfkAFHHEABRx0AAUceFwFHH5ABlxxwAZcdEAGXHoEBlx8AAhccIAIXHRACFx4hAhcfAAFHDAI=</data>
+					<data>
+					ASccMAEnHQABJx6gAScfkAFHHEABRx0AAUce
+					FwFHH5ABlxxwAZcdEAGXHoEBlx8AAhccIAIX
+					HRACFx4hAhcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -486,7 +641,11 @@
 					<key>CodecID</key>
 					<integer>283902501</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfmQG3HCABtx0AAbceFwG3H5kBlxwwAZcdEAGXHoEBlx8CAhccQAIXHRACFx4hAhcfAgG3DAIBRwwCAhcMAg==</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfmQG3HCABtx0AAbce
+					FwG3H5kBlxwwAZcdEAGXHoEBlx8CAhccQAIX
+					HRACFx4hAhcfAgG3DAIBRwwCAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -504,7 +663,12 @@
 					<key>CodecID</key>
 					<integer>283902512</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHosBlx8EAhccQAIXHRACFx4rAhcfBAE3HFABNx0AATceAAE3H0AB1xxgAdcdsAHXHmYB1x9AAUcMAgGXDAI=</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					FwFHH5ABlxwwAZcdEAGXHosBlx8EAhccQAIX
+					HRACFx4rAhcfBAE3HFABNx0AATceAAE3H0AB
+					1xxgAdcdsAHXHmYB1x9AAUcMAgGXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -518,7 +682,11 @@
 					<key>CodecID</key>
 					<integer>283902512</integer>
 					<key>ConfigData</key>
-					<data>AhccEAIXHRACFx4rAhcfBAFHHCABRx0BAUceFwFHH5ABJxwwAScdAQEnHqABJx+QAZccQAGXHRABlx6LAZcfBAFHDAI=</data>
+					<data>
+					AhccEAIXHRACFx4rAhcfBAFHHCABRx0BAUce
+					FwFHH5ABJxwwAScdAQEnHqABJx+QAZccQAGX
+					HRABlx6LAZcfBAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -532,7 +700,11 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfkAGXHCABlx0QAZceqwGXHwMBpxwwAacdAAGnHqABpx+QAhccQAIXHRACFx4rAhcfAwFHDAI=</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfkAGXHCABlx0QAZce
+					qwGXHwMBpxwwAacdAAGnHqABpx+QAhccQAIX
+					HRACFx4rAhcfAwFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -550,7 +722,10 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfkAG3HCABtx0AAbceoAG3H5ACFxwwAhcdEAIXHiECFx8BAUcMAg==</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfkAG3HCABtx0AAbce
+					oAG3H5ACFxwwAhcdEAIXHiECFx8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -568,7 +743,11 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfkAGXHCABlx2QAZceiwGXHwIBtxwwAbcdkAG3HqABtx+QAhccQAIXHUACFx4rAhcfAgFHDAIBtwwC</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfkAGXHCABlx2QAZce
+					iwGXHwIBtxwwAbcdkAG3HqABtx+QAhccQAIX
+					HUACFx4rAhcfAgFHDAIBtwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -586,7 +765,11 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfmQIXHCACFx0QAhceIQIXHwMBpxwwAacdAQGnHqABpx+ZAZccQAGXHRABlx6BAZcfAw==</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfmQIXHCACFx0QAhce
+					IQIXHwMBpxwwAacdAQGnHqABpx+ZAZccQAGX
+					HRABlx6BAZcfAw==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -600,7 +783,11 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQEBRx4XAUcfkAGXHCABlx0QAZcegQGXHwQBtxwwAbcdAQG3HqABtx+QAhccQAIXHRACFx4hAhcfBAFHDAIBtwwCAhcMAg==</data>
+					<data>
+					AUccEAFHHQEBRx4XAUcfkAGXHCABlx0QAZce
+					gQGXHwQBtxwwAbcdAQG3HqABtx+QAhccQAIX
+					HRACFx4hAhcfBAFHDAIBtwwCAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -618,7 +805,11 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQEBJx6mAScfkAGnHDABpx1QAacegQGnHwMBRxwQAUcdAQFHHhcBRx+QAUcMAgIXHCACFx0QAhceIQIXHwMCFwwC</data>
+					<data>
+					ASccQAEnHQEBJx6mAScfkAGnHDABpx1QAace
+					gQGnHwMBRxwQAUcdAQFHHhcBRx+QAUcMAgIX
+					HCACFx0QAhceIQIXHwMCFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -636,7 +827,12 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx4AAScfQAFHHCABRx0AAUceEwFHH5ABtxxAAbcdAAG3HqABtx+QAdccUAHXHZAB1x5FAdcfQAIXHDACFx0QAhceIQIXHwABRwwCAhcMAg==</data>
+					<data>
+					ASccEAEnHQABJx4AAScfQAFHHCABRx0AAUce
+					EwFHH5ABtxxAAbcdAAG3HqABtx+QAdccUAHX
+					HZAB1x5FAdcfQAIXHDACFx0QAhceIQIXHwAB
+					RwwCAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -654,7 +850,11 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQEBRx4TAUcfmQGXHEABlx0QAZcegQGXHwABpxwwAacdAQGnHqABpx+ZAhccIAIXHRACFx4hAhcfAAFHDAI=</data>
+					<data>
+					AUccEAFHHQEBRx4TAUcfmQGXHEABlx0QAZce
+					gQGXHwABpxwwAacdAQGnHqABpx+ZAhccIAIX
+					HRACFx4hAhcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -672,7 +872,11 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>AaccMAGnHQABpx6nAacfkAGXHEABlx0QAZcegQGXHwABRxxQAUcdAAFHHhcBRx+QAUcMAgIXHGACFx0QAhceIQIXHwACFwwC</data>
+					<data>
+					AaccMAGnHQABpx6nAacfkAGXHEABlx0QAZce
+					gQGXHwABRxxQAUcdAAFHHhcBRx+QAUcMAgIX
+					HGACFx0QAhceIQIXHwACFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -690,7 +894,11 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>AhccIAIXHRACFx4hAhcfAAIXDAIBtxwwAbcdAAG3HqcBtx+QAZccQAGXHRABlx6BAZcfAAFHHFABRx0AAUceFwFHH5ABRwwC</data>
+					<data>
+					AhccIAIXHRACFx4hAhcfAAIXDAIBtxwwAbcd
+					AAG3HqcBtx+QAZccQAGXHRABlx6BAZcfAAFH
+					HFABRx0AAUceFwFHH5ABRwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -708,7 +916,12 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABdxwwAXcdAAF3HgABdx9AAZccQAGXHRABlx6LAZcfAAHXHFAB1x2QAdce9wHXH0ACFxxgAhcdEAIXHisCFx8BAUcMAgIXDAI=</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					FwFHH5ABdxwwAXcdAAF3HgABdx9AAZccQAGX
+					HRABlx6LAZcfAAHXHFAB1x2QAdce9wHXH0AC
+					FxxgAhcdEAIXHisCFx8BAUcMAgIXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -726,7 +939,14 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHAEBJxygAScckAFHHAABRxwBAUccEAFHHJABlxwwAZccEAGXHIEBlxwCAhccIAIXHBACFxwhAhccAgF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAUcMAg==</data>
+					<data>
+					ASccEAEnHAEBJxygAScckAFHHAABRxwBAUcc
+					EAFHHJABlxwwAZccEAGXHIEBlxwCAhccIAIX
+					HBACFxwhAhccAgF3HPABdx0AAXceAAF3H0AB
+					hxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4A
+					AacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcd
+					AAHXHgAB1x9AAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -744,7 +964,15 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABlxxAAZcdEAGXHoEBlx8EAhccMAIXHRACFx4hAhcfBAF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFHDAICFwwC</data>
+					<data>
+					ASccIAEnHQEBJx6mAScfkAFHHBABRx0BAUce
+					FwFHH5ABlxxAAZcdEAGXHoEBlx8EAhccMAIX
+					HRACFx4hAhcfBAF3HPABdx0AAXceAAF3H0AB
+					hxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4A
+					AacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcd
+					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFH
+					DAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -762,7 +990,11 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQABJx6gAScfsAFHHBABRx0AAUceFwFHH5ABRwwCAZccMAGXHRABlx6BAZcfAAIXHGACFx0QAhceIQIXHwA=</data>
+					<data>
+					ASccQAEnHQABJx6gAScfsAFHHBABRx0AAUce
+					FwFHH5ABRwwCAZccMAGXHRABlx6BAZcfAAIX
+					HGACFx0QAhceIQIXHwA=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -780,7 +1012,16 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>AbccAAG3HQEBtx6gAbcfmQIXHBACFx0QAhceKwIXHwEBRxwgAUcdAQFHHhABRx+ZAZccMAGXHRABlx6LAZcfAQEnHPABJx0AASceAAEnH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAHXHPAB1x0AAdceAAHXH0AB1xzwAdcdAAHXHgAB1x9A</data>
+					<data>
+					AbccAAG3HQEBtx6gAbcfmQIXHBACFx0QAhce
+					KwIXHwEBRxwgAUcdAQFHHhABRx+ZAZccMAGX
+					HRABlx6LAZcfAQEnHPABJx0AASceAAEnH0AB
+					dxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4A
+					AYcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcd
+					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAHX
+					HPAB1x0AAdceAAHXH0AB1xzwAdcdAAHXHgAB
+					1x9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -796,7 +1037,11 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>AhccIAIXHRACFx4rAhcfAAG3HDABtx0AAbcepwG3H5ABlxwwAZcdEAGXHosBlx8BAUccQAFHHQABRx4XAUcfkAFHDAI=</data>
+					<data>
+					AhccIAIXHRACFx4rAhcfAAG3HDABtx0AAbce
+					pwG3H5ABlxwwAZcdEAGXHosBlx8BAUccQAFH
+					HQABRx4XAUcfkAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -814,7 +1059,11 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQEBRx4XAUcfkAFHDAICFxwfAhcdEAIXHiECFx8CAhcMAgGXHCABlx0QAZceoAGXH5IBpxwwAacdEAGnHoABpx8C</data>
+					<data>
+					AUccEAFHHQEBRx4XAUcfkAFHDAICFxwfAhcd
+					EAIXHiECFx8CAhcMAgGXHCABlx0QAZceoAGX
+					H5IBpxwwAacdEAGnHoABpx8C
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -832,7 +1081,15 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHDABlx0QAZceiwGXHwIBpxwQAacdAQGnHqABpx+QAbccIAG3HQEBtx4XAbcfkAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccQAIXHRACFx4rAhcfAgG3DAICFwwC</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUce
+					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHDABlx0QAZceiwGXHwIB
+					pxwQAacdAQGnHqABpx+QAbccIAG3HQEBtx4X
+					AbcfkAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccQAIXHRACFx4rAhcfAgG3
+					DAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -850,7 +1107,11 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>AbccEAG3HQABtx6gAbcfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHoEBlx8AAhccQAIXHRACFx4hAhcfAQFHDAICFwwC</data>
+					<data>
+					AbccEAG3HQABtx6gAbcfkAFHHCABRx0AAUce
+					FwFHH5ABlxwwAZcdEAGXHoEBlx8AAhccQAIX
+					HRACFx4hAhcfAQFHDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -868,7 +1129,11 @@
 					<key>CodecID</key>
 					<integer>283902517</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQABJx6gAScfsAFHHBABRx0AAUceFwFHH5ABRwwCAZccMAGXHRABlx6BAZcfAAIXHGACFx0QAhceIQIXHwA=</data>
+					<data>
+					ASccQAEnHQABJx6gAScfsAFHHBABRx0AAUce
+					FwFHH5ABRwwCAZccMAGXHRABlx6BAZcfAAIX
+					HGACFx0QAhceIQIXHwA=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -886,7 +1151,11 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHoEBlx8EAhccQAIXHRACFx4hAhcfBAFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
+					FwFHH5ABlxwwAZcdEAGXHoEBlx8EAhccQAIX
+					HRACFx4hAhcfBAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -904,7 +1173,15 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxwwAUcdAQFHHhABRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwgAZcdMAGXHosBlx8BAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHEACFx1AAhceKwIXHwECFwwCABcgAAAXIXIAFyJrABcjEA==</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwwAUcdAQFHHhABRx+QAUcMAgGH
+					HPABhx0AAYceAAGHH0ABlxwgAZcdMAGXHosB
+					lx8BAacc8AGnHQABpx4AAacfQAG3HPABtx0A
+					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHEACFx1AAhceKwIX
+					HwECFwwCABcgAAAXIXIAFyJrABcjEA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -922,7 +1199,11 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUceEAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAQIXHFACFx0QAhceKwIXHwECFwwC</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUce
+					EAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAQIX
+					HFACFx0QAhceKwIXHwECFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -938,7 +1219,15 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUceEAFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHCABlx2QAZceqwGXHwABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHUACFx4rAhcfAAFHDAI=</data>
+					<data>
+					ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUce
+					EAFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHCABlx2QAZceqwGXHwAB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccMAIXHUACFx4rAhcfAAFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -956,7 +1245,11 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUceEAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAAIXHDACFx0QAhceKwIXHwACFwwC</data>
+					<data>
+					ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUce
+					EAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAAIX
+					HDACFx0QAhceKwIXHwACFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -974,7 +1267,15 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwgAUcdkAFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHosBlx8BAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHBACFx0QAhceKwIXHwECFwwC</data>
+					<data>
+					ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwgAUcdkAFHHhcBRx+QAUcMAgGH
+					HPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHosB
+					lx8BAacc8AGnHQABpx4AAacfQAG3HPABtx0A
+					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHBACFx0QAhceKwIX
+					HwECFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -992,7 +1293,11 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUceEAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAAIXHDACFx0QAhceKwIXHwABRwwCAhcMAg==</data>
+					<data>
+					ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUce
+					EAFHH5ABRwwCAZccIAGXHRABlx6LAZcfAAIX
+					HDACFx0QAhceKwIXHwABRwwCAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1010,7 +1315,15 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxzwAZcdEQGXHhEBlx9BAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIXHwICFwwC</data>
+					<data>
+					ASccQAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGH
+					HPABhx0AAYceAAGHH0ABlxzwAZcdEQGXHhEB
+					lx9BAacc8AGnHQABpx4AAacfQAG3HPABtx0A
+					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIX
+					HwICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1028,7 +1341,14 @@
 					<key>CodecID</key>
 					<integer>283902518</integer>
 					<key>ConfigData</key>
-					<data>ATcc8AE3HQABNx4AATcfQAFHHBABRx0BAUceFwFHH5ABRwwCAYcc8AGHHQABhx4AAYcfQAGXHDABlx0QAZcegQGXHwQBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHEUB1x0bAdceZgHXH0AB5xzwAecdAAHnHgAB5x9AAhccHwIXHRACFx4hAhcfBA==</data>
+					<data>
+					ATcc8AE3HQABNx4AATcfQAFHHBABRx0BAUce
+					FwFHH5ABRwwCAYcc8AGHHQABhx4AAYcfQAGX
+					HDABlx0QAZcegQGXHwQBpxzwAacdAAGnHgAB
+					px9AAbcc8AG3HQABtx4AAbcfQAHXHEUB1x0b
+					AdceZgHXH0AB5xzwAecdAAHnHgAB5x9AAhcc
+					HwIXHRACFx4hAhcfBA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1046,7 +1366,11 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHosBlx8AAhccUAIXHRACFx4rAhcfAgFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
+					FwFHH5ABlxwwAZcdEAGXHosBlx8AAhccUAIX
+					HRACFx4rAhcfAgFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1064,7 +1388,15 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHEABlx0QAZceiwGXHwIBpxzwAacdAAGnHgABpx9AAbccIAG3HRABtx4BAbcfAQHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRACFx4rAhcfAgFHDAI=</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHEABlx0QAZceiwGXHwIB
+					pxzwAacdAAGnHgABpx9AAbccIAG3HRABtx4B
+					AbcfAQHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccMAIXHRACFx4rAhcfAgFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1082,7 +1414,11 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>AbccIAG3HQABtx6gAbcfkAFHHDABRx0AAUceFwFHH5ACFxxQAhcdEAIXHiECFx8AAUcMAgIXDAI=</data>
+					<data>
+					AbccIAG3HQABtx6gAbcfkAFHHDABRx0AAUce
+					FwFHH5ACFxxQAhcdEAIXHiECFx8AAUcMAgIX
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1100,7 +1436,10 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6gAScfkAGXHCABlx0RAZcegQGXHwICFxxAAhcdEQIXHiECFx8CAhcMAg==</data>
+					<data>
+					ASccMAEnHQEBJx6gAScfkAGXHCABlx0RAZce
+					gQGXHwICFxxAAhcdEQIXHiECFx8CAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1118,7 +1457,12 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABdxwwAXcdAAF3HgABdx9AAdccQAHXHQAB1x5wAdcfQAIXHFACFx0QAhceIQIXHwIBRwwC</data>
+					<data>
+					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
+					FwFHH5ABdxwwAXcdAAF3HgABdx9AAdccQAHX
+					HQAB1x5wAdcfQAIXHFACFx0QAhceIQIXHwIB
+					RwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1136,7 +1480,13 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABtxwhAbcdAAG3HhcBtx+QAXccMAF3HQABdx4AAXcfQAHXHEAB1x0AAdcecAHXH0ACFxxQAhcdEAIXHiECFx8CAaccYAGnHRABpx6BAacfAgHnHHAB5x0QAeceRQHnHwIBRwwC</data>
+					<data>
+					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
+					FwFHH5ABtxwhAbcdAAG3HhcBtx+QAXccMAF3
+					HQABdx4AAXcfQAHXHEAB1x0AAdcecAHXH0AC
+					FxxQAhcdEAIXHiECFx8CAaccYAGnHRABpx6B
+					AacfAgHnHHAB5x0QAeceRQHnHwIBRwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1154,7 +1504,11 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>AZcc8AGXHRABlx6BAZcfAgGnHDABpx0BAaceoAGnH5ABtxwQAbcdAQG3HhcBtx+QAhccIAIXHRACFx4hAhcfAgG3DAICFwwC</data>
+					<data>
+					AZcc8AGXHRABlx6BAZcfAgGnHDABpx0BAace
+					oAGnH5ABtxwQAbcdAQG3HhcBtx+QAhccIAIX
+					HRACFx4hAhcfAgG3DAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1172,7 +1526,11 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQEBRx4XAUcfkAGXHCABlx0QAZcegQGXHwQCFxwgAhcdEAIXHiECFx8EAbccMAG3HQEBtx6gAbcfkAFHDAI=</data>
+					<data>
+					AUccEAFHHQEBRx4XAUcfkAGXHCABlx0QAZce
+					gQGXHwQCFxwgAhcdEAIXHiECFx8EAbccMAG3
+					HQEBtx6gAbcfkAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1190,7 +1548,10 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>ASccYAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABRwwCAhccMAIXHRACFx4hAhcfAQ==</data>
+					<data>
+					ASccYAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					FwFHH5ABRwwCAhccMAIXHRACFx4hAhcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1208,7 +1569,15 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABRwwCAXccAAF3HQABdx4AAXcfQAGHHPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHoEBlx8EAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xwtAdcdmgHXHvcB1x9AAecc8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIXHwQCFwwC</data>
+					<data>
+					ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUce
+					FwFHH5ABRwwCAXccAAF3HQABdx4AAXcfQAGH
+					HPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHoEB
+					lx8EAacc8AGnHQABpx4AAacfQAG3HPABtx0A
+					AbceAAG3H0AB1xwtAdcdmgHXHvcB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIX
+					HwQCFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1226,7 +1595,11 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfkAFHDAICFxwgAhcdEAIXHiECFx8AAhcMAgEnHDABJx0AAScepgEnH5ABlxxAAZcdAAGXHoEBlx8A</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfkAFHDAICFxwgAhcd
+					EAIXHiECFx8AAhcMAgEnHDABJx0AAScepgEn
+					H5ABlxxAAZcdAAGXHoEBlx8A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1244,7 +1617,11 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQEBJx6mAScfkAFHHCABRx0BAUceFwFHH5ABRwwCAZcccAGXHRABlx6LAZcfAgIXHDACFx0QAhceIQIXHwICFwwC</data>
+					<data>
+					ASccQAEnHQEBJx6mAScfkAFHHCABRx0BAUce
+					FwFHH5ABRwwCAZcccAGXHRABlx6LAZcfAgIX
+					HDACFx0QAhceIQIXHwICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1262,7 +1639,15 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGHHPABhx0AAYceAAGHH0ABlxxwAZcdEAGXHosBlx8CAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHCACFx0QAhceKwIXHwQCFwwC</data>
+					<data>
+					ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUce
+					FwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGH
+					HPABhx0AAYceAAGHH0ABlxxwAZcdEAGXHosB
+					lx8CAacc8AGnHQABpx4AAacfQAG3HPABtx0A
+					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHCACFx0QAhceKwIX
+					HwQCFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1280,7 +1665,15 @@
 					<key>CodecID</key>
 					<integer>283902549</integer>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAZccEAGXHRABlx6LAZcfAgGnHPABpx0AAaceAAGnH0ABtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHJAB5x3gAeceRQHnHwECFxwwAhcdEAIXHisCFx8CAhcMAg==</data>
+					<data>
+					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgF3
+					HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgAB
+					hx9AAZccEAGXHRABlx6LAZcfAgGnHPABpx0A
+					AaceAAGnH0ABtxzwAbcdAAG3HgABtx9AAdcc
+					8AHXHQAB1x4AAdcfQAHnHJAB5x3gAeceRQHn
+					HwECFxwwAhcdEAIXHisCFx8CAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1298,7 +1691,15 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIXHRACFx4rAhcfAgE3HPABNx0AATceAAE3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAG3HDABtx0AAbceoAG3H5AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFHDAIBtwwC</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHCABRx0AAUce
+					FwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIX
+					HRACFx4rAhcfAgE3HPABNx0AATceAAE3H0AB
+					hxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4A
+					AacfQAG3HDABtx0AAbceoAG3H5AB1xzwAdcd
+					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFH
+					DAIBtwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1316,7 +1717,10 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>ASccAAEnHQEBJx6mAScfmQFHHBABRx0BAUceFwFHH5kCFxwgAhcdEAIXHiECFx8BAbcMAg==</data>
+					<data>
+					ASccAAEnHQEBJx6mAScfmQFHHBABRx0BAUce
+					FwFHH5kCFxwgAhcdEAIXHiECFx8BAbcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1334,7 +1738,15 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIXHRACFx4rAhcfAgE3HPABNx0AATceAAE3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					FwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIX
+					HRACFx4rAhcfAgE3HPABNx0AATceAAE3H0AB
+					hxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4A
+					AacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcd
+					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1352,7 +1764,15 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABRwwCAZccMAGXHRABlx6LAZcfAgG3HEABtx0AAbceFwG3H5ABtwwCAhccUAIXHRACFx4rAhcfAgE3HPABNx0AATceAAE3H0ABhxzwAYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9A</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					FwFHH5ABRwwCAZccMAGXHRABlx6LAZcfAgG3
+					HEABtx0AAbceFwG3H5ABtwwCAhccUAIXHRAC
+					Fx4rAhcfAgE3HPABNx0AATceAAE3H0ABhxzw
+					AYcdAAGHHgABhx9AAacc8AGnHQABpx4AAacf
+					QAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHn
+					HgAB5x9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1370,7 +1790,15 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>ASccYAEnHAEBJxymAScckAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhABRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHosBlx8BAacccAGnHQABpx6hAacfAQG3HEEBtx0BAbceEAG3H5ABtwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIXHisCFx8BAhcMAg==</data>
+					<data>
+					ASccYAEnHAEBJxymAScckAE3HPABNx0AATce
+					AAE3H0ABRxxAAUcdAQFHHhABRx+QAUcMAgGH
+					HPABhx0AAYceAAGHH0ABlxwgAZcdEAGXHosB
+					lx8BAacccAGnHQABpx6hAacfAQG3HEEBtx0B
+					AbceEAG3H5ABtwwCAdcc8AHXHQAB1x4AAdcf
+					QAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIX
+					HisCFx8BAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1388,7 +1816,11 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUceFwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIXHRACFx4rAhcfAgFHDAICFwwCAZcHJQIXCIM=</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUce
+					FwFHH5ABlxwwAZcdEAGXHosBlx8CAhccUAIX
+					HRACFx4rAhcfAgFHDAICFwwCAZcHJQIXCIM=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1406,7 +1838,10 @@
 					<key>Comment</key>
 					<string>Andres ZeroCross for Asus VivoBook Pro 17  N705UDR</string>
 					<key>ConfigData</key>
-					<data>AbccUAG3HQEBtx4XAbcfkAGnHDABpx0BAaceoAGnH5ACFxwgAhcdEAIXHiECFx8DAbcMAg==</data>
+					<data>
+					AbccUAG3HQEBtx4XAbcfkAGnHDABpx0BAace
+					oAGnH5ACFxwgAhcdEAIXHiECFx8DAbcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1424,7 +1859,11 @@
 					<key>Comment</key>
 					<string>Andres ZeroCross for Razer Blade 15 RZ09-02705E75</string>
 					<key>ConfigData</key>
-					<data>AUccUAFHHQABRx4XAUcfkAFHDAIBJxwwAScdAAEnHqABJx+QAhccIAIXHRACFx4hAhcfAAGXHEABlx0QAZcegQGXHwQ=</data>
+					<data>
+					AUccUAFHHQABRx4XAUcfkAFHDAIBJxwwAScd
+					AAEnHqABJx+QAhccIAIXHRACFx4hAhcfAAGX
+					HEABlx0QAZcegQGXHwQ=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1442,7 +1881,10 @@
 					<key>Comment</key>
 					<string>vusun123 - ALC256 for Asus X555UJ</string>
 					<key>ConfigData</key>
-					<data>AUccUAFHHQABRx4XAUcfkAFHDAIBpxwwAacdAAGnHqABpx+QAhccIAIXHRACFx4hAhcfAA==</data>
+					<data>
+					AUccUAFHHQABRx4XAUcfkAFHDAIBpxwwAacd
+					AAGnHqABpx+QAhccIAIXHRACFx4hAhcfAA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1460,7 +1902,15 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxxAAZcdEAGXHoEBlx8CAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIXHwICFwwC</data>
+					<data>
+					ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGH
+					HPABhx0AAYceAAGHH0ABlxxAAZcdEAGXHoEB
+					lx8CAacc8AGnHQABpx4AAacfQAG3HPABtx0A
+					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIX
+					HwICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1478,7 +1928,15 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>AScccAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAYcc8AGHHQABhx4AAYcfQAGXHDABlx0QAZceiwGXHwIBpxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4QAbcfkAG3DAIB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHFACFx0QAhceKwIXHwICFwwC</data>
+					<data>
+					AScccAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxzwAUcdAAFHHgABRx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHDABlx0QAZceiwGXHwIB
+					pxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4Q
+					AbcfkAG3DAIB1xzwAdcdAAHXHgAB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHFACFx0QAhceKwIX
+					HwICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1496,7 +1954,15 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAE3HPABNx0AATceAAE3H0ABRxwgAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwwAZcdEAGXHosBlx8CAacc8AGnHQABpx4AAacfQAG3HDABtx0AAbceoAG3H5ABtwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIXHisCFx8CAhcMAgGXByQBtwckAhcIgw==</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAE3HPABNx0AATce
+					AAE3H0ABRxwgAUcdAQFHHhcBRx+QAUcMAgGH
+					HPABhx0AAYceAAGHH0ABlxwwAZcdEAGXHosB
+					lx8CAacc8AGnHQABpx4AAacfQAG3HDABtx0A
+					AbceoAG3H5ABtwwCAdcc8AHXHQAB1x4AAdcf
+					QAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIX
+					HisCFx8CAhcMAgGXByQBtwckAhcIgw==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1514,7 +1980,15 @@
 					<key>CodecID</key>
 					<integer>283902550</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwRAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxxAAZcdEAGXHoEBlx8EAacc8AGnHQABpx4AAacfQAG3HBABtx0BAbceFwG3H5ABtwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIXHiECFx8EAhcMAg==</data>
+					<data>
+					ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwRAUcdAQFHHhcBRx+QAUcMAgGH
+					HPABhx0AAYceAAGHH0ABlxxAAZcdEAGXHoEB
+					lx8EAacc8AGnHQABpx4AAacfQAG3HBABtx0B
+					AbceFwG3H5ABtwwCAdcc8AHXHQAB1x4AAdcf
+					QAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIX
+					HiECFx8EAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1532,7 +2006,11 @@
 					<key>CodecID</key>
 					<integer>283902551</integer>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQABJx6mAScfkAGXHDABlx0QAZcegQGXHwABRxxQAUcdAAFHHhcBRx+QAUcMAgIXHGACFx0QAhceIQIXHwA=</data>
+					<data>
+					ASccIAEnHQABJx6mAScfkAGXHDABlx0QAZce
+					gQGXHwABRxxQAUcdAAFHHhcBRx+QAUcMAgIX
+					HGACFx0QAhceIQIXHwA=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1550,7 +2028,15 @@
 					<key>CodecID</key>
 					<integer>283902551</integer>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGHHPABhx0AAYceAAGHH0ABlxwwAZcdEAGXHosBlx8EAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0ABtwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxwfAhcdEAIXHisCFx8EAhcMAg==</data>
+					<data>
+					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGH
+					HPABhx0AAYceAAGHH0ABlxwwAZcdEAGXHosB
+					lx8EAacc8AGnHQABpx4AAacfQAG3HPABtx0A
+					AbceAAG3H0ABtwwCAdcc8AHXHQAB1x4AAdcf
+					QAHnHPAB5x0AAeceAAHnH0ACFxwfAhcdEAIX
+					HisCFx8EAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1568,7 +2054,12 @@
 					<key>CodecID</key>
 					<integer>283902560</integer>
 					<key>ConfigData</key>
-					<data>IPccECD3HUAg9x4RIPcfASD3DAIhhxwgIYcdYCGHHkQhhx8BITccQCE3HZAhNx6hITcfmSFHHFAhRx0wIUcegSFHHwEhVxxgIVcdQCFXHiEhVx8C</data>
+					<data>
+					IPccECD3HUAg9x4RIPcfASD3DAIhhxwgIYcd
+					YCGHHkQhhx8BITccQCE3HZAhNx6hITcfmSFH
+					HFAhRx0wIUcegSFHHwEhVxxgIVcdQCFXHiEh
+					Vx8C
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1582,7 +2073,10 @@
 					<key>CodecID</key>
 					<integer>283902560</integer>
 					<key>ConfigData</key>
-					<data>AQccAAEHHUABBx4hAQcfAQEnHBABJx2QASceoQEnH5kBNxwgATcdMAE3HoEBNx8B</data>
+					<data>
+					AQccAAEHHUABBx4hAQcfAQEnHBABJx2QASce
+					oQEnH5kBNxwgATcdMAE3HoEBNx8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1596,7 +2090,11 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>AVccYAFXHUABVx4BAVcfAQFHHFABRx1AAUceIQFHHwEBhxwgAYcdMAGHHoEBhx8BAaccEAGnHZABpx6iAacfAQ==</data>
+					<data>
+					AVccYAFXHUABVx4BAVcfAQFHHFABRx1AAUce
+					IQFHHwEBhxwgAYcdMAGHHoEBhx8BAaccEAGn
+					HZABpx6iAacfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1610,7 +2108,12 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4BIUcfASHnHCAh5x1gIeceRSHnHwAhhxwwIYcdkCGHHqEhhx+RIZccQCGXHZAhlx6hIZcfkiGnHFAhpx0wIacegSGnHwEhtxxgIbcdQCG3HiEhtx8C</data>
+					<data>
+					IUccECFHHUAhRx4BIUcfASHnHCAh5x1gIece
+					RSHnHwAhhxwwIYcdkCGHHqEhhx+RIZccQCGX
+					HZAhlx6hIZcfkiGnHFAhpx0wIacegSGnHwEh
+					txxgIbcdQCG3HiEhtx8C
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1624,7 +2127,11 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>AbccEAG3HUABtx4BAbcfAQFXHCABVx0QAVceIQFXHwIBZxwwAWcdAQFnHhMBZx+QAZccQAGXHTABlx6BAZcfAQGnHFABpx0QAacegQGnHwI=</data>
+					<data>
+					AbccEAG3HUABtx4BAbcfAQFXHCABVx0QAVce
+					IQFXHwIBZxwwAWcdAQFnHhMBZx+QAZccQAGX
+					HTABlx6BAZcfAQGnHFABpx0QAacegQGnHwI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1638,7 +2145,11 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAFXHCABVx0QAVceIQFXHwIBhxwwAYcdEAGHHoEBhx8CAZccQAGXHQABlx6jAZcfkAGnHFABpx0QAacegQGnHwE=</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAFXHCABVx0QAVce
+					IQFXHwIBhxwwAYcdEAGHHoEBhx8CAZccQAGX
+					HQABlx6jAZcfkAGnHFABpx0QAacegQGnHwE=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1652,7 +2163,12 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>AZccAAGXHREBlx6gAZcfkgGnHBABpx0xAacegAGnH5EBVxwgAVcdQQFXHhABVx+RAWccMAFnHQEBZx4AAWcfKQGHHEABhx2QAYceoAGHH5EBtxxQAbcdEAG3HisBtx8C</data>
+					<data>
+					AZccAAGXHREBlx6gAZcfkgGnHBABpx0xAace
+					gAGnH5EBVxwgAVcdQQFXHhABVx+RAWccMAFn
+					HQEBZx4AAWcfKQGHHEABhx2QAYceoAGHH5EB
+					txxQAbcdEAG3HisBtx8C
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1666,7 +2182,11 @@
 					<key>CodecID</key>
 					<integer>283902562</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4hAUcfAgFXHB8BVx0QAVceAQFXHwEBZxwgAWcdAQFnHhMBZx+ZAYccMAGHHTABhx6BAYcfAQGnHD8Bpx2QAaceoQGnHwI=</data>
+					<data>
+					AUccEAFHHUABRx4hAUcfAgFXHB8BVx0QAVce
+					AQFXHwEBZxwgAWcdAQFnHhMBZx+ZAYccMAGH
+					HTABhx6BAYcfAQGnHD8Bpx2QAaceoQGnHwI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1680,7 +2200,11 @@
 					<key>CodecID</key>
 					<integer>283902568</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHRABRx4hAUcfAQGHHEABhx2QAYcegQGHHwEBVxxQAVcdAAFXHhMBVx+QAZccYAGXHQABlx6jAZcfkAFXDAI=</data>
+					<data>
+					AUccEAFHHRABRx4hAUcfAQGHHEABhx2QAYce
+					gQGHHwEBVxxQAVcdAAFXHhMBVx+QAZccYAGX
+					HQABlx6jAZcfkAFXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1694,7 +2218,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AYccIAGHHRABhx6BAYcfBAGXHBABlx0BAZceoAGXH5kBtxxAAbcdAQG3HhMBtx+ZAhccUAIXHRACFx4hAhcfBAFHDAI=</data>
+					<data>
+					AYccIAGHHRABhx6BAYcfBAGXHBABlx0BAZce
+					oAGXH5kBtxxAAbcdAQG3HhMBtx+ZAhccUAIX
+					HRACFx4hAhcfBAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1712,7 +2240,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AUccQAFHHQEBRx4TAUcfmQGHHCABhx0QAYcegQGHHwMBlxwQAZcdAQGXHqABlx+ZAhccUAIXHRACFx4hAhcfAwFHDAI=</data>
+					<data>
+					AUccQAFHHQEBRx4TAUcfmQGHHCABhx0QAYce
+					gQGHHwMBlxwQAZcdAQGXHqABlx+ZAhccUAIX
+					HRACFx4hAhcfAwFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1732,7 +2264,15 @@
 					<key>Comment</key>
 					<string>Mirone - Realtek ALC269 for Asus K53SJ, Asus G73s</string>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceEwFHH5ABdxxQAXcdAQF3HhMBdx+QAYccIAGHHZABhx6BAYcfAwGXHDABlx0BAZceoAGXH5ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAwFHDAI=</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
+					EwFHH5ABdxxQAXcdAQF3HhMBdx+QAYccIAGH
+					HZABhx6BAYcfAwGXHDABlx0BAZceoAGXH5AB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAwFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1750,7 +2290,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAGHHCABhx2QAYcegQGHHwIBtxwwAbcdEAG3HqABtx+QAhccQAIXHRACFx4hAhcfAgFHDAI=</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAGHHCABhx2QAYce
+					gQGHHwIBtxwwAbcdEAG3HqABtx+QAhccQAIX
+					HRACFx4hAhcfAgFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1768,7 +2312,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					EwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIX
+					HRACFx4hAhcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1786,7 +2334,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAGHHDABhx0QAYcegQGHHwABJxxAAScdAAEnHqABJx+QAVccUAFXHRABVx4hAVcfAAFHDAI=</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAGHHDABhx0QAYce
+					gQGHHwABJxxAAScdAAEnHqABJx+QAVccUAFX
+					HRABVx4hAVcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1804,7 +2356,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfkAFXHCABVx0QAVceIQFXHwABhxwwAYcdEAGHHoEBhx8CAbccQAG3HQABtx4XAbcfkAG3DAI=</data>
+					<data>
+					ASccEAEnHQABJx6mAScfkAFXHCABVx0QAVce
+					IQFXHwABhxwwAYcdEAGHHoEBhx8CAbccQAG3
+					HQABtx4XAbcfkAG3DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1818,7 +2374,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABVxwwAVcdEAFXHiEBVx8AAYccQAGHHZABhx6BAYcfAgFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
+					FwFHH5ABVxwwAVcdEAFXHiEBVx8AAYccQAGH
+					HZABhx6BAYcfAgFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1836,7 +2396,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					EwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIX
+					HRACFx4hAhcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1854,7 +2418,14 @@
 					<key>Comment</key>
 					<string>Toleda ALC269 patch for Brix</string>
 					<key>ConfigData</key>
-					<data>IUcc8CFHHQAhRx4AIUcfQCFXHHAhVx1AIVceISFXHwIhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHPAhhx0AIYceACGHH0AhlxzwIZcdACGXHgAhlx9AIacc8CGnHQAhpx4AIacfQCG3HPAhtx0AIbceACG3H0Ah5xyQIecdYSHnHksh5x8B</data>
+					<data>
+					IUcc8CFHHQAhRx4AIUcfQCFXHHAhVx1AIVce
+					ISFXHwIhZxzwIWcdACFnHgAhZx9AIXcc8CF3
+					HQAhdx4AIXcfQCGHHPAhhx0AIYceACGHH0Ah
+					lxzwIZcdACGXHgAhlx9AIacc8CGnHQAhpx4A
+					IacfQCG3HPAhtx0AIbceACG3H0Ah5xyQIecd
+					YSHnHksh5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1868,7 +2439,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AbccIAG3HUABtx4BAbcfAQGHHDABhx2YAYcegQGHHwIBlxxAAZcdmAGXHoEBlx8BAhccUAIXHUACFx4hAhcfAg==</data>
+					<data>
+					AbccIAG3HUABtx4BAbcfAQGHHDABhx2YAYce
+					gQGHHwIBlxxAAZcdmAGXHoEBlx8BAhccUAIX
+					HUACFx4hAhcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1882,7 +2457,15 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxwgAacdEAGnHisBpx8AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhcc8AIXHQACFx4AAhcfQAFHDAI=</data>
+					<data>
+					ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
+					pxwgAacdEAGnHisBpx8AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhcc8AIXHQACFx4AAhcfQAFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1900,7 +2483,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AZccEAGXHQABlx6nAZcfmQFXHCABVx0QAVceIQFXHwIBhxwwAYcdEAGHHoEBhx8CAUccQAFHHQABRx4XAUcfmQFHDAI=</data>
+					<data>
+					AZccEAGXHQABlx6nAZcfmQFXHCABVx0QAVce
+					IQFXHwIBhxwwAYcdEAGHHoEBhx8CAUccQAFH
+					HQABRx4XAUcfmQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1918,7 +2505,15 @@
 					<key>Comment</key>
 					<string>Custom ALC269VC for Samsung NT550P7C-S65 with subwoofer 2.1ch by Rockjesus</string>
 					<key>ConfigData</key>
-					<data>AVccEAFXHRABVx4hAVcfAQGHHCABhx0QAYcegQGHHwEBlxwwAZcdAQGXHqcBlx+QAbccQAG3HQEBtx4XAbcfkAF3HEEBdx0BAXceFwF3H5ABJxzwAScdAAEnHgABJx9AAUcc8AFHHQABRx4AAUcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAG3DAI=</data>
+					<data>
+					AVccEAFXHRABVx4hAVcfAQGHHCABhx0QAYce
+					gQGHHwEBlxwwAZcdAQGXHqcBlx+QAbccQAG3
+					HQEBtx4XAbcfkAF3HEEBdx0BAXceFwF3H5AB
+					JxzwAScdAAEnHgABJx9AAUcc8AFHHQABRx4A
+					AUcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcd
+					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAG3
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1932,7 +2527,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AbccIAG3HUABtx4BAbcfAQGHHDABhx2QAYcegQGHHwIBlxxAAZcdkAGXHoEBlx8BAhccUAIXHUACFx4hAhcfAg==</data>
+					<data>
+					AbccIAG3HUABtx4BAbcfAQGHHDABhx2QAYce
+					gQGHHwIBlxxAAZcdkAGXHoEBlx8BAhccUAIX
+					HUACFx4hAhcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1946,7 +2545,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AbccIAG3HUABtx4RAbcfkAGHHDABhx2QAYceoQGHH5ABlxxAAZcdkAGXHoEBlx8BAhccUAIXHUACFx4hAhcfAg==</data>
+					<data>
+					AbccIAG3HUABtx4RAbcfkAGHHDABhx2QAYce
+					oQGHH5ABlxxAAZcdkAGXHoEBlx8BAhccUAIX
+					HUACFx4hAhcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1960,7 +2563,10 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AYccIAGHHVABhx6hAYcfkQFXHDABVx1AAVceIQFXHwEBVwwC</data>
+					<data>
+					AYccIAGHHVABhx6hAYcfkQFXHDABVx1AAVce
+					IQFXHwEBVwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1978,7 +2584,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUceEAFHH5ABVxxQAVcdEAFXHiEBVx8BAYcccAGHHRABhx6hAYcfAQFHDAI=</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUce
+					EAFHH5ABVxxQAVcdEAFXHiEBVx8BAYcccAGH
+					HRABhx6hAYcfAQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -1996,7 +2606,15 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccIAIXHRACFx4rAhcfAAFHDAI=</data>
+					<data>
+					ASccMAEnHQEBJx6mAScfkAFHHBABRx0BAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccIAIXHRACFx4rAhcfAAFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2016,7 +2634,11 @@
 					<key>Comment</key>
 					<string>Custom ALC269 Sony Vaio VPCEB3M1R by Rodion</string>
 					<key>ConfigData</key>
-					<data>AVccQAFXHRABVx4hAVcfAwGHHCABhx0QAYcegQGHHwMBlxwwAZcdAQGXHqABlx+QAbccEAG3HQEBtx4XAbcfkAFXDAI=</data>
+					<data>
+					AVccQAFXHRABVx4hAVcfAwGHHCABhx0QAYce
+					gQGHHwMBlxwwAZcdAQGXHqABlx+QAbccEAG3
+					HQEBtx4XAbcfkAFXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2030,7 +2652,15 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceEwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGHHDABhx2QAYcegQGHHwIBlxxAAZcdkAGXHoEBlx8BAacc8AGnHQABpx4AAacfQAG3HCABtx1AAbceAQG3HwEB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHFACFx1AAhceIQIXHwI=</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
+					EwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGH
+					HDABhx2QAYcegQGHHwIBlxxAAZcdkAGXHoEB
+					lx8BAacc8AGnHQABpx4AAacfQAG3HCABtx1A
+					AbceAQG3HwEB1xzwAdcdAAHXHgAB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHFACFx1AAhceIQIX
+					HwI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2046,7 +2676,11 @@
 					<key>Comment</key>
 					<string>Custom ALC269 for Acer Aspire by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>AUccAAFHHUEBRx4XAUcfmQGHHBABhx2QAYcegQGHHwEBtxwgAbcdkQG3HqcBtx+ZAhccMAIXHUACFx4hAhcfAQ==</data>
+					<data>
+					AUccAAFHHUEBRx4XAUcfmQGHHBABhx2QAYce
+					gQGHHwEBtxwgAbcdkQG3HqcBtx+ZAhccMAIX
+					HUACFx4hAhcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2062,7 +2696,11 @@
 					<key>Comment</key>
 					<string>ALC269VC for Lenovo Z580, John</string>
 					<key>ConfigData</key>
-					<data>AVccQAFXHRABVx4hAVcfAwGHHCABhx0QAYcegQGHHwMBlxwwAZcdAQGXHqABlx+QAbccEAG3HQEBtx4XAbcfkAFXDAI=</data>
+					<data>
+					AVccQAFXHRABVx4hAVcfAwGHHCABhx0QAYce
+					gQGHHwMBlxwwAZcdAQGXHqABlx+QAbccEAG3
+					HQEBtx4XAbcfkAFXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2076,7 +2714,11 @@
 					<key>Comment</key>
 					<string>ALC269VC for Lenovo V580, ar4er</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABVxwwAVcdEAFXHiEBVx8AAYccQAGHHZABhx6BAYcfAgFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUce
+					FwFHH5ABVxwwAVcdEAFXHiEBVx8AAYccQAGH
+					HZABhx6BAYcfAgFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2094,7 +2736,12 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfkAFHHBABRx0BAUceFwFHH5ABVxyAAVcdEAFXHiEBVx8CAYccIAGHHRABhx6BAYcfAgHnHGAB5x0AAeceQQHnHwIBRwwC</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfkAFHHBABRx0BAUce
+					FwFHH5ABVxyAAVcdEAFXHiEBVx8CAYccIAGH
+					HRABhx6BAYcfAgHnHGAB5x0AAeceQQHnHwIB
+					RwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2112,7 +2759,11 @@
 					<key>Comment</key>
 					<string>Custom ALC269 Samsung np880z5e-x01ru by Constanta</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfkAG3HCABtx0AAbceFwG3H5ABVxwwAVcdEAFXHiEBVx8AAYccQAGHHZABhx6BAYcfAgG3DAI=</data>
+					<data>
+					ASccEAEnHQABJx6mAScfkAG3HCABtx0AAbce
+					FwG3H5ABVxwwAVcdEAFXHiEBVx8AAYccQAGH
+					HZABhx6BAYcfAgG3DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2126,7 +2777,11 @@
 					<key>Comment</key>
 					<string>Custom ALC269VC for Samsung NP530U3C-A0F by BblDE3HAP</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQEBRx4XAUcfkAFHDAIBVxxAAVcdEAFXHiEBVx8DAVcMAgGHHCABhx0QAYcegQGHHwMBlxwwAZcdAQGXHqABlx+Q</data>
+					<data>
+					AUccEAFHHQEBRx4XAUcfkAFHDAIBVxxAAVcd
+					EAFXHiEBVx8DAVcMAgGHHCABhx0QAYcegQGH
+					HwMBlxwwAZcdAQGXHqABlx+Q
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2144,7 +2799,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfkAGHHCABhx0QAYcegQGHHwIBVxwwAVcdEAFXHiEBVx8CAZccQAGXHQABlx6gAZcfkAFHDAI=</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfkAGHHCABhx0QAYce
+					gQGHHwIBVxwwAVcdEAFXHiEBVx8CAZccQAGX
+					HQABlx6gAZcfkAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2162,7 +2821,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABRwwCAVccIAFXHRABVx4hAVcfAAGHHDABhx0QAYcegQGHHwA=</data>
+					<data>
+					ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUce
+					FwFHH5ABRwwCAVccIAFXHRABVx4hAVcfAAGH
+					HDABhx0QAYcegQGHHwA=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2182,7 +2845,11 @@
 					<key>Comment</key>
 					<string>Laptop patch ALC269VC Samsung _NP350V5C - Giesteira</string>
 					<key>ConfigData</key>
-					<data>AUccAAFHHQABRx4XAUcfmQGHHBABhx0QAYcegQGHHwEBVxwgAVcdEAFXHiEBVx8BAZccMAGXHQABlx6nAZcfmQFHDAI=</data>
+					<data>
+					AUccAAFHHQABRx4XAUcfmQGHHBABhx0QAYce
+					gQGHHwEBVxwgAVcdEAFXHiEBVx8BAZccMAGX
+					HQABlx6nAZcfmQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2200,7 +2867,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfmQGHHCABhx0QAYcegQGHHwEBJxwwAScdAAEnHqYBJx+ZAhccUAIXHRACFx4hAhcfAQFHDAI=</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfmQGHHCABhx0QAYce
+					gQGHHwEBJxwwAScdAAEnHqYBJx+ZAhccUAIX
+					HRACFx4hAhcfAQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2218,7 +2889,15 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUceFwFHH5ABRwwCAVccUAFXHRABVx4rAVcfAgFXDAIBdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6LAYcfAgGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccYAG3HUABtx4BAbcfAQHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9A</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUce
+					FwFHH5ABRwwCAVccUAFXHRABVx4rAVcfAgFX
+					DAIBdxzwAXcdAAF3HgABdx9AAYccIAGHHRAB
+					hx6LAYcfAgGXHPABlx0AAZceAAGXH0ABpxzw
+					AacdAAGnHgABpx9AAbccYAG3HUABtx4BAbcf
+					AQHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHn
+					HgAB5x9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2236,7 +2915,15 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAGHHDABhx0QAYcegQGHHwABJxxAAScdAAEnHqABJx+QAVccIAFXHRABVx4hAVcfAAF3HPABdx0AAXceAAF3H0ABlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAeccYAHnHRAB5x5EAecfAgFHDAI=</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAGHHDABhx0QAYce
+					gQGHHwABJxxAAScdAAEnHqABJx+QAVccIAFX
+					HRABVx4hAVcfAAF3HPABdx0AAXceAAF3H0AB
+					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
+					AacfQAG3HPABtx0AAbceAAG3H0AB1xzwAdcd
+					AAHXHgAB1x9AAeccYAHnHRAB5x5EAecfAgFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2250,7 +2937,14 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUceFwFHH5ABVxwgAVcdEAFXHiEBVx8CAXcc8AF3HQABdx4AAXcfQAGHHAABhx0QAYcegQGHHwIBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB5xxwAecdEQHnHkQB5x8CAUcMAg==</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUce
+					FwFHH5ABVxwgAVcdEAFXHiEBVx8CAXcc8AF3
+					HQABdx4AAXcfQAGHHAABhx0QAYcegQGHHwIB
+					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
+					AacfQAG3HPABtx0AAbceAAG3H0AB5xxwAecd
+					EQHnHkQB5x8CAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2268,7 +2962,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQEBRx4TAUcfkAGHHCABhx0QAYcegQGHHwEBlxwgAZcdAQGXHqABlx+QAhccEAIXHRACFx4hAhcfAQFHDAI=</data>
+					<data>
+					AUccEAFHHQEBRx4TAUcfkAGHHCABhx0QAYce
+					gQGHHwEBlxwgAZcdAQGXHqABlx+QAhccEAIX
+					HRACFx4hAhcfAQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2286,7 +2984,14 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUceFwFHH5ABVxwgAVcdEAFXHiEBVx8CAXcc8AF3HQABdx4AAXcfQAGHHAABhx0QAYcegQGHHwIBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0AB5xzwAecdAAHnHgAB5x9AAUcMAg==</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUce
+					FwFHH5ABVxwgAVcdEAFXHiEBVx8CAXcc8AF3
+					HQABdx4AAXcfQAGHHAABhx0QAYcegQGHHwIB
+					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
+					AacfQAG3HPABtx0AAbceAAG3H0AB5xzwAecd
+					AAHnHgAB5x9AAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2306,7 +3011,15 @@
 					<key>Comment</key>
 					<string>ALC269 Asus K53SJ, Asus G73s Mod by Andrey1970 (No input boost - no noise in Siri)</string>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceEwFHH5ABdxxQAXcdAQF3HhMBdx+QAYccIAGHHZABhx6BAYcfAwGXHDABlx0BAZceoAGXH5ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAwFHDAI=</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
+					EwFHH5ABdxxQAXcdAQF3HhMBdx+QAYccIAGH
+					HZABhx6BAYcfAwGXHDABlx0BAZceoAGXH5AB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAwFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2324,7 +3037,11 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					EwFHH5ABhxwwAYcdEAGHHoEBhx8AAhccUAIX
+					HRACFx4hAhcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2344,7 +3061,11 @@
 					<key>Comment</key>
 					<string>ALC269 for GPD P2 Max by DalianSky</string>
 					<key>ConfigData</key>
-					<data>AVccEAFXHRABVx4hAVcfBAGnHCABpx0BAaceFwGnH5ABpwwCAYccMAGHHRABhx6BAYcfBAEnHEABJx0BAScepgEnH7c=</data>
+					<data>
+					AVccEAFXHRABVx4hAVcfBAGnHCABpx0BAace
+					FwGnH5ABpwwCAYccMAGHHRABhx6BAYcfBAEn
+					HEABJx0BAScepgEnH7c=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2364,7 +3085,11 @@
 					<key>Comment</key>
 					<string>Custom ALC269 Acer Aspire by Andrey1970 (No input boost - no noise in Siri)</string>
 					<key>ConfigData</key>
-					<data>AUccAAFHHUEBRx4XAUcfmQGHHBABhx2QAYcegQGHHwEBtxwgAbcdkQG3HqcBtx+ZAhccMAIXHUACFx4hAhcfAQ==</data>
+					<data>
+					AUccAAFHHUEBRx4XAUcfmQGHHBABhx2QAYce
+					gQGHHwEBtxwgAbcdkQG3HqcBtx+ZAhccMAIX
+					HUACFx4hAhcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2380,7 +3105,12 @@
 					<key>Comment</key>
 					<string>ALC269 for Lenovo Y500 by BaoStorm (No input boost - no noise in Siri)</string>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQkBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABRwwCAVccIAFXHSABVx4hAVcfBAFXDAIBhxxQAYcdKAGHHqEBhx8EAeccMAHnHSEB5x5FAecfBA==</data>
+					<data>
+					ASccQAEnHQkBJx6mAScfkAFHHBABRx0BAUce
+					FwFHH5ABRwwCAVccIAFXHSABVx4hAVcfBAFX
+					DAIBhxxQAYcdKAGHHqEBhx8EAeccMAHnHSEB
+					5x5FAecfBA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2394,7 +3124,15 @@
 					<key>CodecID</key>
 					<integer>283902569</integer>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYccEAGHHRABhx6AAYcfkAGXHBABlx0AAZceoAGXH5ABpxyQAacdAQGnHhcBpx+QAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xxwAecdEQHnHkQB5x8EAhccoAIXHRACFx4hAhcfBAFHDAI=</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUce
+					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYccEAGH
+					HRABhx6AAYcfkAGXHBABlx0AAZceoAGXH5AB
+					pxyQAacdAQGnHhcBpx+QAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xxwAecd
+					EQHnHkQB5x8EAhccoAIXHRACFx4hAhcfBAFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2408,7 +3146,10 @@
 					<key>CodecID</key>
 					<integer>283902576</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAGXHCABlx0AAZceoAGXH5ACFxwwAhcdEAIXHiECFx8AAUcMAg==</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAGXHCABlx0AAZce
+					oAGXH5ACFxwwAhcdEAIXHiECFx8AAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2426,7 +3167,10 @@
 					<key>CodecID</key>
 					<integer>283902576</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ACFxwwAhcdEAIXHiECFx8BAUcMAg==</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					EwFHH5ACFxwwAhcdEAIXHiECFx8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2446,7 +3190,15 @@
 					<key>Comment</key>
 					<string>ALC270 for Asus A46CB-WX024D Laptop by Andres ZeroCross</string>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfBAGXHDABlx0BAZceoAGXH5ABpxwgAacdEAGnHiEBpx8EAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhcc8AIXHQACFx4AAhcfQAFHDAI=</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGH
+					HRABhx6BAYcfBAGXHDABlx0BAZceoAGXH5AB
+					pxwgAacdEAGnHiEBpx8EAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhcc8AIXHQACFx4AAhcfQAFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2466,7 +3218,15 @@
 					<key>Comment</key>
 					<string>ALC270 for Asus Laptop with alternative microphone</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHCABRx0BAUceEwFHH5ABdxzwAXcdAAF3HgABdx9AAYccMAGHHRABhx6BAYcfAgGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAgFHDAI=</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHCABRx0BAUce
+					EwFHH5ABdxzwAXcdAAF3HgABdx9AAYccMAGH
+					HRABhx6BAYcfAgGXHPABlx0AAZceAAGXH0AB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccQAIXHRACFx4hAhcfAgFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2486,7 +3246,15 @@
 					<key>Comment</key>
 					<string>ALC270 for Asus Laptop</string>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfBAGXHDABlx0BAZceoAGXH5ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccIAIXHRACFx4hAhcfBAFHDAI=</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHBABRx0BAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGH
+					HRABhx6BAYcfBAGXHDABlx0BAZceoAGXH5AB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccIAIXHRACFx4hAhcfBAFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2504,7 +3272,12 @@
 					<key>Comment</key>
 					<string>Custom ALC271x Acer Aspire s3-951</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ABhxwwAYcdkAGHHoEBhx8AAdccQAHXHZAB1x4XAdcfQAHnHFAB5x0QAeceRQHnHwACFxxgAhcdEAIXHiECFx8AAUcMAg==</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					EwFHH5ABhxwwAYcdkAGHHoEBhx8AAdccQAHX
+					HZAB1x4XAdcfQAHnHFAB5x0QAeceRQHnHwAC
+					FxxgAhcdEAIXHiECFx8AAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2522,7 +3295,11 @@
 					<key>CodecID</key>
 					<integer>283902578</integer>
 					<key>ConfigData</key>
-					<data>AYccMAGHHZABhx6BAYcfAAGXHCABlx0AAZceowGXH5ABRxwQAUcdAAFHHhMBRx+QAhccUAIXHUACFx4hAhcfAAFHDAI=</data>
+					<data>
+					AYccMAGHHZABhx6BAYcfAAGXHCABlx0AAZce
+					owGXH5ABRxwQAUcdAAFHHhMBRx+QAhccUAIX
+					HUACFx4hAhcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2540,7 +3317,11 @@
 					<key>CodecID</key>
 					<integer>283902578</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6jAScfkAFHHBABRx0AAUceEwFHH5ABhxwgAYcdEAGHHoEBhx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
+					<data>
+					ASccMAEnHQABJx6jAScfkAFHHBABRx0AAUce
+					EwFHH5ABhxwgAYcdEAGHHoEBhx8AAhccUAIX
+					HRACFx4hAhcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2558,7 +3339,11 @@
 					<key>CodecID</key>
 					<integer>283902578</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUceEwFHH5ABRwwCAYccMAGHHZABhx6BAYcfAQIXHEACFx1AAhceIQIXHwE=</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUce
+					EwFHH5ABRwwCAYccMAGHHZABhx6BAYcfAQIX
+					HEACFx1AAhceIQIXHwE=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2572,7 +3357,11 @@
 					<key>CodecID</key>
 					<integer>283902578</integer>
 					<key>ConfigData</key>
-					<data>AYccQAGHHZABhx6BAYcfAQEnHDABJx0BASceoAEnH5ABpxwQAacdAQGnHhMBpx+ZAhccIAIXHRACFx4hAhcfAQ==</data>
+					<data>
+					AYccQAGHHZABhx6BAYcfAQEnHDABJx0BASce
+					oAEnH5ABpxwQAacdAQGnHhMBpx+ZAhccIAIX
+					HRACFx4hAhcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2586,7 +3375,11 @@
 					<key>CodecID</key>
 					<integer>283902580</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6gAScfkAFnHBABZx0BAWceFwFnH5ABlxxAAZcdAAGXHoEBlx8EAhccIAIXHRACFx4hAhcfBAFHDAICFwwC</data>
+					<data>
+					ASccMAEnHQEBJx6gAScfkAFnHBABZx0BAWce
+					FwFnH5ABlxxAAZcdAAGXHoEBlx8EAhccIAIX
+					HRACFx4hAhcfBAFHDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2604,7 +3397,10 @@
 					<key>CodecID</key>
 					<integer>283902581</integer>
 					<key>ConfigData</key>
-					<data>ASccAAEnHQABJx6gAScfkAFHHBABRx0BAUceFwFHH5ABVxwgAVcdEAFXHiEBVx8DAUcMAg==</data>
+					<data>
+					ASccAAEnHQABJx6gAScfkAFHHBABRx0BAUce
+					FwFHH5ABVxwgAVcdEAFXHiEBVx8DAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2622,7 +3418,12 @@
 					<key>CodecID</key>
 					<integer>283902581</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQEBRx4XAUcfkAFXHCABVx0QAVceIQFXHwMBJxwwAScdAAEnHqABJx+QAYccQAGHHVABhx6BAYcfAAHnHFAB5x0QAeceRQHnHwABRwwC</data>
+					<data>
+					AUccEAFHHQEBRx4XAUcfkAFXHCABVx0QAVce
+					IQFXHwMBJxwwAScdAAEnHqABJx+QAYccQAGH
+					HVABhx6BAYcfAAHnHFAB5x0QAeceRQHnHwAB
+					RwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2640,7 +3441,11 @@
 					<key>CodecID</key>
 					<integer>283902581</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQABJx6gAScfkAFXHBABVx0QAVceIQFXHwABhxwwAYcdUAGHHoEBhx8AAaccUAGnHQABpx4XAacfkAGnDAI=</data>
+					<data>
+					ASccQAEnHQABJx6gAScfkAFXHBABVx0QAVce
+					IQFXHwABhxwwAYcdUAGHHoEBhx8AAaccUAGn
+					HQABpx4XAacfkAGnDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2654,7 +3459,11 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAFXHCABVx0QAVceIQFXHwEBJxwwAScdAAEnHqABJx+QAaccQAGnHRABpx6BAacfAgFHDAIBVwwC</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAFXHCABVx0QAVce
+					IQFXHwEBJxwwAScdAAEnHqABJx+QAaccQAGn
+					HRABpx6BAacfAgFHDAIBVwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2672,7 +3481,11 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABVxwwAVcdEAFXHiEBVx8CAaccQAGnHRABpx6BAacfAgFHDAIBVwwC</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					FwFHH5ABVxwwAVcdEAFXHiEBVx8CAaccQAGn
+					HRABpx6BAacfAgFHDAIBVwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2690,7 +3503,14 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>IUcc8CFHHQAhRx4AIUcfQCFXHPAhVx0AIVceACFXH0AhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHPAhhx0AIYceACGHH0AhlxzwIZcdACGXHgAhlx9AIacc8CGnHQAhpx4AIacfQCG3HPAhtx0AIbceACG3H0Ah5xwQIecd4SHnHkUh5x8B</data>
+					<data>
+					IUcc8CFHHQAhRx4AIUcfQCFXHPAhVx0AIVce
+					ACFXH0AhZxzwIWcdACFnHgAhZx9AIXcc8CF3
+					HQAhdx4AIXcfQCGHHPAhhx0AIYceACGHH0Ah
+					lxzwIZcdACGXHgAhlx9AIacc8CGnHQAhpx4A
+					IacfQCG3HPAhtx0AIbceACG3H0Ah5xwQIecd
+					4SHnHkUh5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2704,7 +3524,11 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>AbccIAG3HUABtx4BAbcfAQGnHDABpx2QAacegQGnHwIBhxxAAYcdMAGHHoEBhx8BAVccYAFXHUABVx4hAVcfAgFXDAI=</data>
+					<data>
+					AbccIAG3HUABtx4BAbcfAQGnHDABpx2QAace
+					gQGnHwIBhxxAAYcdMAGHHoEBhx8BAVccYAFX
+					HUABVx4hAVcfAgFXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2718,7 +3542,11 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>AbccIAG3HUABtx4RAbcfkAGnHDABpx2QAacegQGnHwIBhxxAAYcdMAGHHoEBhx8BAVccYAFXHUABVx4hAVcfAgFXDAI=</data>
+					<data>
+					AbccIAG3HUABtx4RAbcfkAGnHDABpx2QAace
+					gQGnHwIBhxxAAYcdMAGHHoEBhx8BAVccYAFX
+					HUABVx4hAVcfAgFXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2732,7 +3560,11 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>AaccMAGnHZABpx6BAacfAgGHHEABhx0wAYcegQGHHwEBRxxQAUcdAAFHHhcBRx+QAUcMAgFXHGABVx1AAVceIQFXHwIBVwwC</data>
+					<data>
+					AaccMAGnHZABpx6BAacfAgGHHEABhx0wAYce
+					gQGHHwEBRxxQAUcdAAFHHhcBRx+QAUcMAgFX
+					HGABVx1AAVceIQFXHwIBVwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2750,7 +3582,11 @@
 					<key>CodecID</key>
 					<integer>283902592</integer>
 					<key>ConfigData</key>
-					<data>AVccIAFXHUABVx4hAVcfAgGHHDABhx0AAYceoAGHH5ABpxxAAacdkAGnHoEBpx8CAbccEAG3HQABtx4AAbcfAQFnDAI=</data>
+					<data>
+					AVccIAFXHUABVx4hAVcfAgGHHDABhx0AAYce
+					oAGHH5ABpxxAAacdkAGnHoEBpx8CAbccEAG3
+					HQABtx4AAbcfAQFnDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2764,7 +3600,11 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfmQFHHCABRx0AAUceEwGXHDABlx0QAZceiwGXHwABRx+ZAhccUAIXHRACFx4rAhcfAQFHDAICFwwC</data>
+					<data>
+					ASccEAEnHQABJx6gAScfmQFHHCABRx0AAUce
+					EwGXHDABlx0QAZceiwGXHwABRx+ZAhccUAIX
+					HRACFx4rAhcfAQFHDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2782,7 +3622,12 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABhxwwAYcdEAGHHoEBhx8AAeccIAHnHRAB5x5EAecfAAIXHFACFx0QAhceIQIXHwABRwwC</data>
+					<data>
+					ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUce
+					FwFHH5ABhxwwAYcdEAGHHoEBhx8AAeccIAHn
+					HRAB5x5EAecfAAIXHFACFx0QAhceIQIXHwAB
+					RwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2800,7 +3645,12 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABhxwwAYcdEAGHHoEBhx8AAeccIAHnHRAB5x5EAecfAAIXHFACFx0QAhceIQIXHwABRwwC</data>
+					<data>
+					ASccQAEnHQABJx6gAScfkAFHHBABRx0AAUce
+					FwFHH5ABhxwwAYcdEAGHHoEBhx8AAeccIAHn
+					HRAB5x5EAecfAAIXHFACFx0QAhceIQIXHwAB
+					RwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2818,7 +3668,15 @@
 					<key>Comment</key>
 					<string>Custom ALC282 lenovo y430p by loverto</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUcdAAFHH0ABdxzwAXcdAAF3HgABdx9AAYcccAGHHRABhx6BAYcfAQGHHAIBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HEABtx0BAbceFwG3H5AB1xzwAdcdAAHXHgAB1x9AAeccYAHnHRAB5x5EAecfAQIXHFACFx0QAhceIQIXHwECFxwC</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUcd
+					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYcccAGH
+					HRABhx6BAYcfAQGHHAIBlxzwAZcdAAGXHgAB
+					lx9AAacc8AGnHQABpx4AAacfQAG3HEABtx0B
+					AbceFwG3H5AB1xzwAdcdAAHXHgAB1x9AAecc
+					YAHnHRAB5x5EAecfAQIXHFACFx0QAhceIQIX
+					HwECFxwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2836,7 +3694,14 @@
 					<key>Comment</key>
 					<string>Skvo ALC282 Acer Aspire on IvyBridge by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIXHiECFx8B</data>
+					<data>
+					ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcd
+					EAIXHiECFx8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2850,7 +3715,14 @@
 					<key>Comment</key>
 					<string>Custom ALC282 Acer Aspire E1-572G</string>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx0AAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccMAG3HQEBtx6gAbcfkAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIXHiECFx8B</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHBABRx0AAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
+					pxzwAacdAAGnHgABpx9AAbccMAG3HQEBtx6g
+					AbcfkAHnHPAB5x0AAeceAAHnH0ACFxwgAhcd
+					EAIXHiECFx8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2864,7 +3736,11 @@
 					<key>Comment</key>
 					<string>Custom ALC282 Dell Inspirion 3521 by Generation88</string>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQEBJx6gAScfkAFHHBABRx0BAUceFwFHH5ABlxwwAZcdEAGXHoEBlx8BAhccIAIXHRACFx4hAhcfAQFHDAI=</data>
+					<data>
+					ASccQAEnHQEBJx6gAScfkAFHHBABRx0BAUce
+					FwFHH5ABlxwwAZcdEAGXHoEBlx8BAhccIAIX
+					HRACFx4hAhcfAQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2882,7 +3758,15 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4XAbcfkAHXHPAB1x0AAdceAAHXH0AB5xxwAecdEAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFHDAI=</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUce
+					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYccIAGH
+					HRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0AB
+					pxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4X
+					AbcfkAHXHPAB1x0AAdceAAHXH0AB5xxwAecd
+					EAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2900,7 +3784,15 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4XAbcfkAHXHPAB1x0AAdceAAHXH0AB5xxwAecdEAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFHDAI=</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHPABRx0AAUce
+					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYccIAGH
+					HRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0AB
+					pxzwAacdAAGnHgABpx9AAbccQAG3HQEBtx4X
+					AbcfkAHXHPAB1x0AAdceAAHXH0AB5xxwAecd
+					EAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2918,7 +3810,15 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xxwAecdEAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFHDAI=</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYccIAGH
+					HRABhx6BAYcfAQGXHPABlx0AAZceAAGXH0AB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xxwAecd
+					EAHnHkQB5x8BAhccUAIXHRACFx4hAhcfAQFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2936,7 +3836,15 @@
 					<key>CodecID</key>
 					<integer>283902594</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHCABRx1AAUceEQFHHwEBdxzwAXcdAAF3HgABdx9AAYccIAGHHRABhx6BAYcfAQGXHPABlx0AAZceAQGXH0ABpxzwAacdAAGnHgEBpx9AAdcc8AG3HQABtx4BAbcfQAHXHPUB1x0AAdceBQHXH0AB5xzwAecdAAHnHgEB5x9AAhccQAIXHXACFx4hAhcfAQFHDAI=</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHCABRx1AAUce
+					EQFHHwEBdxzwAXcdAAF3HgABdx9AAYccIAGH
+					HRABhx6BAYcfAQGXHPABlx0AAZceAQGXH0AB
+					pxzwAacdAAGnHgEBpx9AAdcc8AG3HQABtx4B
+					AbcfQAHXHPUB1x0AAdceBQHXH0AB5xzwAecd
+					AAHnHgEB5x9AAhccQAIXHXACFx4hAhcfAQFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2954,7 +3862,15 @@
 					<key>Comment</key>
 					<string>Custom ALC282 for Asus x200la</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6BAScfAAFHHCABRx0BAUceEAFHH5kBdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHDABlx0BAZcepgGXH5kBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccUAIXHUACFx4rAhcfAAFHDAICFwwC</data>
+					<data>
+					ASccEAEnHQABJx6BAScfAAFHHCABRx0BAUce
+					EAFHH5kBdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHDABlx0BAZcepgGXH5kB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccUAIXHUACFx4rAhcfAAFH
+					DAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2972,7 +3888,14 @@
 					<key>Comment</key>
 					<string>No input boost ALC282 Acer Aspire on IvyBridge by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcdEAIXHiECFx8B</data>
+					<data>
+					ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHnHPAB5x0AAeceAAHnH0ACFxwgAhcd
+					EAIXHiECFx8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -2986,7 +3909,15 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUceAAFHH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHGABlx0wAZceiwGXHwEBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhcccAIXHUACFx4rAhcfAQGXDAICFwwC</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHPABRx0AAUce
+					AAFHH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHGABlx0wAZceiwGXHwEB
+					pxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhcccAIXHUACFx4rAhcfAQGX
+					DAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3000,7 +3931,11 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUceFwFHH5ABlxwwAZcdAAGXHosBlx8AAhccQAIXHRACFx4rAhcfAQFHDAICFwwC</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfkAFHHCABRx0BAUce
+					FwFHH5ABlxwwAZcdAAGXHosBlx8AAhccQAIX
+					HRACFx4rAhcfAQFHDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3018,7 +3953,15 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUceFwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx8AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccUAIXHRACFx4hAhcfAwFHDAICFwwC</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfkAFHHEABRx0BAUce
+					FwFHH5ABdxzwAXcdAAF3HgABdx9AAYcc8AGH
+					HQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0AB
+					pxzwAacdAAGnHgABpx8AAbcc8AG3HQABtx4A
+					AbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAhccUAIXHRACFx4hAhcfAwFH
+					DAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3036,7 +3979,11 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfkAFHDAIBlxwgAZcdEAGXHoEBlx8AASccMAEnHQABJx6mAScfkAIXHGACFx0QAhceIQIXHwACFwwC</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfkAFHDAIBlxwgAZcd
+					EAGXHoEBlx8AASccMAEnHQABJx6mAScfkAIX
+					HGACFx0QAhceIQIXHwACFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3054,7 +4001,12 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>AbccQAG3HQABtx4XAbcfmQEnHBABJx0AAScepgEnH5kBlxwgAZcdkAGXHoEBlx8BAaccMAGnHZABpx6BAacfAQIXHAACFx1AAhceIQIXHwEBRwwC</data>
+					<data>
+					AbccQAG3HQABtx4XAbcfmQEnHBABJx0AASce
+					pgEnH5kBlxwgAZcdkAGXHoEBlx8BAaccMAGn
+					HZABpx6BAacfAQIXHAACFx1AAhceIQIXHwEB
+					RwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3072,7 +4024,12 @@
 					<key>CodecID</key>
 					<integer>283902595</integer>
 					<key>ConfigData</key>
-					<data>ASccgAEnHQABJx4AAScfQAFHHEABRx0BAUceEwFHH5ABpxwgAacdkAGnHoEBpx8BAdccYAHXHZAB1x5VAdcfQAIXHFACFx0QAhceIQIXHwEBRwwCAhcMAg==</data>
+					<data>
+					ASccgAEnHQABJx4AAScfQAFHHEABRx0BAUce
+					EwFHH5ABpxwgAacdkAGnHoEBpx8BAdccYAHX
+					HZAB1x5VAdcfQAIXHFACFx0QAhceIQIXHwEB
+					RwwCAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3090,7 +4047,12 @@
 					<key>CodecID</key>
 					<integer>283902596</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAE3HCABNx0AATceAAE3H0ABRxwwAUcdAAFHHhcBRx+QAVccQAFXHRABVx4hAVcfAAGHHFABhx0QAYcegQGHHwIB1xxgAdcdgAHXHmYB1x9AAUcMAg==</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAE3HCABNx0AATce
+					AAE3H0ABRxwwAUcdAAFHHhcBRx+QAVccQAFX
+					HRABVx4hAVcfAAGHHFABhx0QAYcegQGHHwIB
+					1xxgAdcdgAHXHmYB1x9AAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3108,7 +4070,12 @@
 					<key>CodecID</key>
 					<integer>283902597</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUceFwFHH5ABlxwAAZcdEAGXHosBlx8BAhccIAIXHRACFx4rAhcfAQHXHGAB1x2AAdceZgHXH0ABRwwC</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUce
+					FwFHH5ABlxwAAZcdEAGXHosBlx8BAhccIAIX
+					HRACFx4rAhcfAQHXHGAB1x2AAdceZgHXH0AB
+					RwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3126,7 +4093,11 @@
 					<key>CodecName</key>
 					<string>Andres - Realtek ALC285 for  Lenovo X1 Carbon 6th </string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUceFwFHH5ABlxwAAZcdEAGXHosBlx8EAhccIAIXHRACFx4rAhcfBAFHDAI=</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUce
+					FwFHH5ABlxwAAZcdEAGXHosBlx8EAhccIAIX
+					HRACFx4rAhcfBAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3144,7 +4115,15 @@
 					<key>CodecName</key>
 					<string>Flymin - Realtek ALC285 for  Thinkpad X1E</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFnHPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHCABlx0QAZceiwGXHwQBpxzwAacdAAGnHgABpx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxxQAhcdEAIXHisCFx8EAhcMAg==</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFn
+					HPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgAB
+					dx9AAYcc8AGHHQABhx4AAYcfQAGXHCABlx0Q
+					AZceiwGXHwQBpxzwAacdAAGnHgABpx9AAdcc
+					8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHn
+					H0ACFxxQAhcdEAIXHisCFx8EAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3162,7 +4141,11 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC286</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfsAFHHCABRx0AAUceFwFHH5ABhxwwAYcdEAGHHosBhx8EAhccQAIXHRACFx4rAhcfBAFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6mAScfsAFHHCABRx0AAUce
+					FwFHH5ABhxwwAYcdEAGHHosBhx8EAhccQAIX
+					HRACFx4rAhcfBAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3180,7 +4163,15 @@
 					<key>CodecName</key>
 					<string>Lenovo YOGA3 pro ALC286 - gdllzkusi</string>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgF3HPABdx0AAXceAAF3H0ABhxwQAYcdEAGHHoEBhx8EAZcc8AGXHQABlx4AAZcfQAGnHPABpx0AAaceAAGnH0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHDACFx0QAhceIQIXHwQCFwwC</data>
+					<data>
+					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgF3
+					HPABdx0AAXceAAF3H0ABhxwQAYcdEAGHHoEB
+					hx8EAZcc8AGXHQABlx4AAZcfQAGnHPABpx0A
+					AaceAAGnH0AB1xzwAdcdAAHXHgAB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHDACFx0QAhceIQIX
+					HwQCFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3198,7 +4189,12 @@
 					<key>CodecID</key>
 					<integer>283902600</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAE3HCABNx0AATceAAE3H0ABRxwwAUcdAAFHHhcBRx+QAYccQAGHHRABhx6BAYcfAgHXHFAB1x2AAdceZQHXH0ACFxxgAhcdEAIXHiECFx8BAUcMAg==</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAE3HCABNx0AATce
+					AAE3H0ABRxwwAUcdAAFHHhcBRx+QAYccQAGH
+					HRABhx6BAYcfAgHXHFAB1x2AAdceZQHXH0AC
+					FxxgAhcdEAIXHiECFx8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3216,7 +4212,11 @@
 					<key>CodecID</key>
 					<integer>283902600</integer>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQABJx6gAScfkAFHHDABRx0AAUceFwFHH5ABNxxAATcdEAE3HoEBNx8AAhccUAIXHRACFx4hAhcfAAFHDAI=</data>
+					<data>
+					ASccIAEnHQABJx6gAScfkAFHHDABRx0AAUce
+					FwFHH5ABNxxAATcdEAE3HoEBNx8AAhccUAIX
+					HRACFx4hAhcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3234,7 +4234,15 @@
 					<key>CodecID</key>
 					<integer>283902600</integer>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4AAZcfQAGnHHABpx0gAacYqwGnHwIBpwwCAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxw/AhcdEAIXHisCFx8D</data>
+					<data>
+					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgF3
+					HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgAB
+					hx9AAZcc8AGXHQABlx4AAZcfQAGnHHABpx0g
+					AacYqwGnHwIBpwwCAdcc8AHXHQAB1x4AAdcf
+					QAHnHPAB5x0AAeceAAHnH0ACFxw/AhcdEAIX
+					HisCFx8D
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3252,7 +4260,11 @@
 					<key>CodecID</key>
 					<integer>283902601</integer>
 					<key>ConfigData</key>
-					<data>ATccMAE3HQEBNx6mATcftwFHHBABRx0BAUceFwFHH5ABRwwCAbccQAG3HRABtx6BAbcfAwG3DAICFxwgAhcdEAIXHiECFx8DAhcMAg==</data>
+					<data>
+					ATccMAE3HQEBNx6mATcftwFHHBABRx0BAUce
+					FwFHH5ABRwwCAbccQAG3HRABtx6BAbcfAwG3
+					DAICFxwgAhcdEAIXHiECFx8DAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3270,7 +4282,11 @@
 					<key>CodecID</key>
 					<integer>283902608</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfkAFXHCABVx0QAVceKwFXHwIBlxwwAZcdAAGXHqABlx+QAaccQAGnHRABpx6LAacfAAFHDAI=</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfkAFXHCABVx0QAVce
+					KwFXHwIBlxwwAZcdAAGXHqABlx+QAaccQAGn
+					HRABpx6LAacfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3288,7 +4304,11 @@
 					<key>Comment</key>
 					<string>macpeetALC ALC290 aka ALC3241</string>
 					<key>ConfigData</key>
-					<data>AaccIAGnHRABpx6BAacfAAEnHDABJx0AASceowEnH5ABRxxAAUcdAAFHHhcBRx+QAVccUAFXHRABVx4hAVcfAAFHDAI=</data>
+					<data>
+					AaccIAGnHRABpx6BAacfAAEnHDABJx0AASce
+					owEnH5ABRxxAAUcdAAFHHhcBRx+QAVccUAFX
+					HRABVx4hAVcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3306,7 +4326,11 @@
 					<key>Comment</key>
 					<string>vusun123 - ALC 290 for Dell Vostro 5480</string>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABRwwCAVccIAFXHRABVx4hAVcfAAGnHEABpx0QAacegQGnHwA=</data>
+					<data>
+					ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUce
+					FwFHH5ABRwwCAVccIAFXHRABVx4hAVcfAAGn
+					HEABpx0QAacegQGnHwA=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3324,7 +4348,11 @@
 					<key>CodecID</key>
 					<integer>283902610</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfmQFHHCABRx0AAUceFwFHH5kBVxwwAVcdQAFXHiEBVx8BAZccUAGXHZABlx6BAZcfAQFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6gAScfmQFHHCABRx0AAUce
+					FwFHH5kBVxwwAVcdQAFXHiEBVx8BAZccUAGX
+					HZABlx6BAZcfAQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3342,7 +4370,11 @@
 					<key>CodecID</key>
 					<integer>283902610</integer>
 					<key>ConfigData</key>
-					<data>AaccIAGnHRABpx6BAacfAAEnHDABJx0AAScepgEnH5ABRxxAAUcdAAFHHhcBRx+QAUcMAgFXHFABVx0QAVceAQFXHwABVwwC</data>
+					<data>
+					AaccIAGnHRABpx6BAacfAAEnHDABJx0AASce
+					pgEnH5ABRxxAAUcdAAFHHhcBRx+QAUcMAgFX
+					HFABVx0QAVceAQFXHwABVwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3360,7 +4392,11 @@
 					<key>Comment</key>
 					<string>vanquybn - ALC 292 for Dell M4800</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfkAGHHCABhx2QAYcegQGHHwEBJxwwAScdAAEnHqYBJx+QAVccQAFXHUABVx4hAVcfAQ==</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfkAGHHCABhx2QAYce
+					gQGHHwEBJxwwAScdAAEnHqYBJx+QAVccQAFX
+					HUABVx4hAVcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3374,7 +4410,11 @@
 					<key>Comment</key>
 					<string>vusun123 - ALC 292 for Lenovo T440</string>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6gAScfkAFHHEABRx0AAUceFwFHH5ABRwwCAVccUAFXHRABVx4hAVcfAAGnHCABpx0QAacegQGnHwA=</data>
+					<data>
+					ASccMAEnHQABJx6gAScfkAFHHEABRx0AAUce
+					FwFHH5ABRwwCAVccUAFXHRABVx4hAVcfAAGn
+					HCABpx0QAacegQGnHwA=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3392,7 +4432,15 @@
 					<key>Comment</key>
 					<string>ALC292 for Lenovo T450s By Echo</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRx0BAUceFwFHH5ABRwwCAVccQAFXHRABVx4rAVcfBAFXDAIBZxzwAWcdAAFnHgABZx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxwgAacdEAGnHosBpx8EAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAUccMA==</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRx0BAUceFwFHH5ABRwwCAVccQAFX
+					HRABVx4rAVcfBAFXDAIBZxzwAWcdAAFnHgAB
+					Zx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0A
+					AZceAAGXH0ABpxwgAacdEAGnHosBpx8EAbcc
+					8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHX
+					H0AB5xzwAecdAAHnHgAB5x9AAUccMA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3406,7 +4454,15 @@
 					<key>Comment</key>
 					<string>baesar0 -ALC 292 for e6540 with dock</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFXHFABVx1AAVceKwFXHwIBVwwCAWccgAFnHUABZx4BAWcfAgFnDAIBhxzwAYcdAAGHHgABhx9AAZccIAGXHZABlx6BAZcfAgGnHHABpx0QAaceqwGnHwIBtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0A=</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFX
+					HFABVx1AAVceKwFXHwIBVwwCAWccgAFnHUAB
+					Zx4BAWcfAgFnDAIBhxzwAYcdAAGHHgABhx9A
+					AZccIAGXHZABlx6BAZcfAgGnHHABpx0QAace
+					qwGnHwIBtxzwAbcdAAG3HgABtx9AAdcc8AHX
+					HQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3424,7 +4480,15 @@
 					<key>CodecID</key>
 					<integer>283902611</integer>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAE3HBABNx0BATceoAE3H5ABRxwwAUcdAQFHHhcBRx+QAVccQAFXHUABVx4rAVcfAgFnHFABZx1AAWceAQFnHwIBhxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4AAZcfQAGnHCABpx0QAaceiwGnHwIBtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ABRwwCAVcMAgFnDAI=</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAE3HBABNx0BATce
+					oAE3H5ABRxwwAUcdAQFHHhcBRx+QAVccQAFX
+					HUABVx4rAVcfAgFnHFABZx1AAWceAQFnHwIB
+					hxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4A
+					AZcfQAGnHCABpx0QAaceiwGnHwIBtxzwAbcd
+					AAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHn
+					HPAB5x0AAeceAAHnH0ABRwwCAVcMAgFnDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3442,7 +4506,15 @@
 					<key>CodecID</key>
 					<integer>283902611</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwgAUcdAQFHHhcBRx+QAVccMAFXHRABVx4hAVcfAwFnHPABZx0AAWceAAFnH0ABhxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4AAZcfQAGnHEABpx0QAacegQGnHwMBtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ABRwwCAVcMAg==</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwgAUcdAQFHHhcBRx+QAVccMAFX
+					HRABVx4hAVcfAwFnHPABZx0AAWceAAFnH0AB
+					hxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4A
+					AZcfQAGnHEABpx0QAacegQGnHwMBtxzwAbcd
+					AAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHn
+					HPAB5x0AAeceAAHnH0ABRwwCAVcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3460,7 +4532,15 @@
 					<key>CodecID</key>
 					<integer>283902611</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwgAUcdAQFHHhcBRx+QAVccMAFXHRABVx4hAVcfAwFnHPABZx0AAWceAAFnH0ABhxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4AAZcfQAGnHEABpx0QAacegQGnHwMBtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ABRwwCAVcMAg==</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwgAUcdAQFHHhcBRx+QAVccMAFX
+					HRABVx4hAVcfAwFnHPABZx0AAWceAAFnH0AB
+					hxzwAYcdAAGHHgABhx9AAZcc8AGXHQABlx4A
+					AZcfQAGnHEABpx0QAacegQGnHwMBtxzwAbcd
+					AAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHn
+					HPAB5x0AAeceAAHnH0ABRwwCAVcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3478,7 +4558,11 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>AbccEAG3HQEBtx6nAbcfkAFHHCABRx0BAUceFwFHH5ACFxwwAhcdEAIXHiECFx8BAUcMAgG3DAICFwwC</data>
+					<data>
+					AbccEAG3HQEBtx6nAbcfkAFHHCABRx0BAUce
+					FwFHH5ACFxwwAhcdEAIXHiECFx8BAUcMAgG3
+					DAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3492,7 +4576,11 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>AhccIAIXHRACFx4hAhcfAAGXHDABlx0QAZcegQGXHwABpxxAAacdkAGnHoEBpx8AAUccUAFHHQABRx4XAUcfkAFHDAI=</data>
+					<data>
+					AhccIAIXHRACFx4hAhcfAAGXHDABlx0QAZce
+					gQGXHwABpxxAAacdkAGnHoEBpx8AAUccUAFH
+					HQABRx4XAUcfkAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3506,7 +4594,10 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASceoAEnH5ACFxwwAhcdEAIXHiECFx8A</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASce
+					oAEnH5ACFxwwAhcdEAIXHiECFx8A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3520,7 +4611,11 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQEBJx6gAScfkAF3HBABdx0BAXceFwF3H5ABlxxAAZcdEAGXHoEBlx8EAhccMAIXHRACFx4hAhcfBAF3DAICFwwC</data>
+					<data>
+					ASccIAEnHQEBJx6gAScfkAF3HBABdx0BAXce
+					FwF3H5ABlxxAAZcdEAGXHoEBlx8EAhccMAIX
+					HRACFx4hAhcfBAF3DAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3538,7 +4633,12 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>ATccAAE3HQABNx4QATcfQAFHHBABRx0BAUceFwFHH5ABRwwCAZccIAGXHRABlx6BAZcfBAIXHDACFx0QAhceIQIXHwQCFwwCAdccQAHXHZoB1x5nAdcfQAEnHFABJx0BASceoAEnH5A=</data>
+					<data>
+					ATccAAE3HQABNx4QATcfQAFHHBABRx0BAUce
+					FwFHH5ABRwwCAZccIAGXHRABlx6BAZcfBAIX
+					HDACFx0QAhceIQIXHwQCFwwCAdccQAHXHZoB
+					1x5nAdcfQAEnHFABJx0BASceoAEnH5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3556,7 +4656,11 @@
 					<key>CodecID</key>
 					<integer>283902612</integer>
 					<key>ConfigData</key>
-					<data>AhccIAIXHRACFx4hAhcfAQG3HDABtx0BAbcepwG3H5ABlxwwAZcdEAGXHoEBlx8BAUccEAFHHQEBRx4XAUcfkAFHDAIBtwwCAhcMAg==</data>
+					<data>
+					AhccIAIXHRACFx4hAhcfAQG3HDABtx0BAbce
+					pwG3H5ABlxwwAZcdEAGXHoEBlx8BAUccEAFH
+					HQEBRx4XAUcfkAFHDAIBtwwCAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3574,7 +4678,16 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAUcMAgFnHPABZx0AAWceAAFnH0ABdxwQAXcdAQF3HhcBdx+QAYcc8AGHHQABhx4BAYcfQAGXHEABlx0QAZcegQGXHwIBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAG3DAIB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4BAecfQAIXHCACFx0QAhceIQIXHwICFwwC</data>
+					<data>
+					ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxzwAUcdAAFHHgABRx9AAUcMAgFn
+					HPABZx0AAWceAAFnH0ABdxwQAXcdAQF3HhcB
+					dx+QAYcc8AGHHQABhx4BAYcfQAGXHEABlx0Q
+					AZcegQGXHwIBpxzwAacdAAGnHgABpx9AAbcc
+					8AG3HQABtx4AAbcfQAG3DAIB1xzwAdcdAAHX
+					HgAB1x9AAecc8AHnHQAB5x4BAecfQAIXHCAC
+					Fx0QAhceIQIXHwICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3592,7 +4705,11 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6mAScfmQF3HCABdx0AAXceFwF3H5kBlxwwAZcdEAGXHoEBlx8CAhccQAIXHRACFx4hAhcfAgF3DAIBRwwCAhcMAg==</data>
+					<data>
+					ASccEAEnHQABJx6mAScfmQF3HCABdx0AAXce
+					FwF3H5kBlxwwAZcdEAGXHoEBlx8CAhccQAIX
+					HRACFx4hAhcfAgF3DAIBRwwCAhcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3610,7 +4727,16 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFnHPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHBABlx0QAZcegQGXHwIBpxzwAacdAAGnHgABpx9AAbcc8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRACFx4hAhcfAgIXDAI=</data>
+					<data>
+					ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxxAAUcdAQFHHhcBRx+QAUcMAgFn
+					HPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgAB
+					dx9AAYcc8AGHHQABhx4AAYcfQAGXHBABlx0Q
+					AZcegQGXHwIBpxzwAacdAAGnHgABpx9AAbcc
+					8AG3HQABtx4AAbcfQAHXHPAB1x0AAdceAAHX
+					H0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRAC
+					Fx4hAhcfAgIXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3628,7 +4754,11 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASceoAEnH5ACFxwwAhcdEAIXHiECFx8AAZccQAGXHRABlx6BAZcfAAIXDAI=</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASce
+					oAEnH5ACFxwwAhcdEAIXHiECFx8AAZccQAGX
+					HRABlx6BAZcfAAIXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3642,7 +4772,11 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4XAUcfkAEnHCABJx0AASceoAEnH5ACFxwwAhcdEAIXHiECFx8AAZccQAGXHRABlx6BAZcfAA==</data>
+					<data>
+					AUccEAFHHQABRx4XAUcfkAEnHCABJx0AASce
+					oAEnH5ACFxwwAhcdEAIXHiECFx8AAZccQAGX
+					HRABlx6BAZcfAA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3656,7 +4790,16 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>ASccIAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAZccMAGXHRABlx6BAZcfAgGnHPABpx0AAaceAAGnH0ABtxzwAbcdAAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACFxxAAhcdEAIXHiECFx8CAUcMAgIXDAI=</data>
+					<data>
+					ASccIAEnHQEBJx6gAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAWcc8AFn
+					HQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0AB
+					hxzwAYcdAAGHHgABhx9AAZccMAGXHRABlx6B
+					AZcfAgGnHPABpx0AAaceAAGnH0ABtxzwAbcd
+					AAG3HgABtx9AAdcc8AHXHQAB1x4AAdcfQAHn
+					HPAB5x0AAeceAAHnH0ACFxxAAhcdEAIXHiEC
+					Fx8CAUcMAgIXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3670,7 +4813,11 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6gAScfuQFHHFABRx0AAUceFwFHH5ABRwwCAZccQAGXHRABlx6BAZcfAAIXHCACFx0QAhceIQIXHwA=</data>
+					<data>
+					ASccMAEnHQABJx6gAScfuQFHHFABRx0AAUce
+					FwFHH5ABRwwCAZccQAGXHRABlx6BAZcfAAIX
+					HCACFx0QAhceIQIXHwA=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3688,7 +4835,16 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6mAScftwE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgFnHPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgABdx9AAYcc8AGHHQABhx4AAYcfQAGXHHABlx0gAZceqwGXHwIBpxzwAacdAAGnHgABpx9AAbcc8AG3GwABtx4AAbcfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRACFx4rAhcfAgIXDAI=</data>
+					<data>
+					ASccMAEnHQEBJx6mAScftwE3HPABNx0AATce
+					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgFn
+					HPABZx0AAWceAAFnH0ABdxzwAXcdAAF3HgAB
+					dx9AAYcc8AGHHQABhx4AAYcfQAGXHHABlx0g
+					AZceqwGXHwIBpxzwAacdAAGnHgABpx9AAbcc
+					8AG3GwABtx4AAbcfQAHXHPAB1x0AAdceAAHX
+					H0AB5xzwAecdAAHnHgAB5x9AAhccMAIXHRAC
+					Fx4rAhcfAgIXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3706,7 +4862,11 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABhxwwAYcdEAGHHoEBhx8CAhccQAIXHRACFx4hAhcfAgFHDAICFwwC</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					FwFHH5ABhxwwAYcdEAGHHoEBhx8CAhccQAIX
+					HRACFx4hAhcfAgFHDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3724,7 +4884,11 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQEBJx6mAScftwF3HBABdx0BAXceFwF3H5ABpxwwAacdEAGnHqEBpx8DAhccIAIXHRACFx4hAhcfAw==</data>
+					<data>
+					ASccQAEnHQEBJx6mAScftwF3HBABdx0BAXce
+					FwF3H5ABpxwwAacdEAGnHqEBpx8DAhccIAIX
+					HRACFx4hAhcfAw==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3738,7 +4902,11 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASceoAEnH5ACFxwwAhcdEAIXHiECFx8CAYccQAGHHRABhx6BAYcfAgFHDAICFwwC</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkAEnHCABJx0AASce
+					oAEnH5ACFxwwAhcdEAIXHiECFx8CAYccQAGH
+					HRABhx6BAYcfAgFHDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3756,7 +4924,15 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAXcc8AF3HQABdx4AAXcfQAGHHHABhx0QAYcegQGHHwABlxzwAZcdAAGXHgABlx9AAaccUAGnHQEBpx4XAacfkAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIXHCACFx0QAhceIQIXHwABpwwC</data>
+					<data>
+					ASccMAEnHQEBJx6gAScfkAE3HPABNx0AATce
+					AAE3H0ABRxzwAUcdAAFHHgABRx9AAXcc8AF3
+					HQABdx4AAXcfQAGHHHABhx0QAYcegQGHHwAB
+					lxzwAZcdAAGXHgABlx9AAaccUAGnHQEBpx4X
+					AacfkAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIX
+					HCACFx0QAhceIQIXHwABpwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3774,7 +4950,15 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxwQAUcdAQFHHhcBRx+QAXcc8AF3HQABdx4AAXcfQAGHHEABhx0QAYcegQGHHwMBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIXHCACFx0QAhceIQIXHwMBRwwC</data>
+					<data>
+					ASccMAEnHQEBJx6gAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAXcc8AF3
+					HQABdx4AAXcfQAGHHEABhx0QAYcegQGHHwMB
+					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
+					AacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIX
+					HCACFx0QAhceIQIXHwMBRwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3792,7 +4976,10 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6gAScfkAF3HEABdx0AAXceFwF3H5ABdwwCAhccIAIXHRACFx4hAhcfAA==</data>
+					<data>
+					ASccMAEnHQABJx6gAScfkAF3HEABdx0AAXce
+					FwF3H5ABdwwCAhccIAIXHRACFx4hAhcfAA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3806,7 +4993,21 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>AEcc8ABHHQAARx4AAEcfAABXHPAAVx0AAFceAABXHwAAdxzwAHcdAAB3HgAAdx8AAOcc8ADnHQAA5x4AAOcfAAD3HPAA9x0AAPceAAD3HwABBxzwAQcdAAEHHgABBx8AASccQAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3HwABRxwQAUcdAQFHHhcBRx+QAUcMAgFXHPABVx0AAVceAAFXHwABZxzwAWcdAAFnHgABZx8AAXcc8AF3HQABdx4AAXcfAAGHHDABhx0QAYcegQGHHwMBlxzwAZcdAAGXHgABlx8AAacc8AGnHQABpx4AAacfAAG3HPABtx0AAbceAAG3HwABxxzwAccdAAHHHgABxx8AAdcc8AHXHQAB1x4AAdcfAAHnHPAB5x0AAeceAAHnHwAB9xzwAfcdAAH3HgAB9x8AAgcc8AIHHQACBx4AAgcfAA==</data>
+					<data>
+					AEcc8ABHHQAARx4AAEcfAABXHPAAVx0AAFce
+					AABXHwAAdxzwAHcdAAB3HgAAdx8AAOcc8ADn
+					HQAA5x4AAOcfAAD3HPAA9x0AAPceAAD3HwAB
+					BxzwAQcdAAEHHgABBx8AASccQAEnHQEBJx6g
+					AScfkAE3HPABNx0AATceAAE3HwABRxwQAUcd
+					AQFHHhcBRx+QAUcMAgFXHPABVx0AAVceAAFX
+					HwABZxzwAWcdAAFnHgABZx8AAXcc8AF3HQAB
+					dx4AAXcfAAGHHDABhx0QAYcegQGHHwMBlxzw
+					AZcdAAGXHgABlx8AAacc8AGnHQABpx4AAacf
+					AAG3HPABtx0AAbceAAG3HwABxxzwAccdAAHH
+					HgABxx8AAdcc8AHXHQAB1x4AAdcfAAHnHPAB
+					5x0AAeceAAHnHwAB9xzwAfcdAAH3HgAB9x8A
+					Agcc8AIHHQACBx4AAgcfAA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3824,7 +5025,11 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6gAScfkAF3HEABdx0AAXceFwF3H5ABdwwCAYcccAGHHRABhx6BAYcfAAIXHCACFx0QAhceIQIXHwA=</data>
+					<data>
+					ASccMAEnHQABJx6gAScfkAF3HEABdx0AAXce
+					FwF3H5ABdwwCAYcccAGHHRABhx6BAYcfAAIX
+					HCACFx0QAhceIQIXHwA=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3842,7 +5047,15 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfmQF3HEABdx0BAXceFwF3H5ABdwwCAYcc8AGHHQABhx4AAYcfQAGnHPABpx0AAaceAAGnH0ACFxxQAhcdEAIXHiECFx8BATcc8AE3HQABNx4AATcfQAFHHPABRx0AAUceAAFHH0ABlxzwAZcdAAGXHgABlx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0AB9xzwAfcdAAH3HgAB9x9A</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfmQF3HEABdx0BAXce
+					FwF3H5ABdwwCAYcc8AGHHQABhx4AAYcfQAGn
+					HPABpx0AAaceAAGnH0ACFxxQAhcdEAIXHiEC
+					Fx8BATcc8AE3HQABNx4AATcfQAFHHPABRx0A
+					AUceAAFHH0ABlxzwAZcdAAGXHgABlx9AAdcc
+					8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHn
+					H0AB9xzwAfcdAAH3HgAB9x9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3860,7 +5073,11 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceFwFHH5ABhxwwAYcdEAGHHoEBhx8CAhccQAIXHRACFx4hAhcfAgFHDAICFwwC</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					FwFHH5ABhxwwAYcdEAGHHoEBhx8CAhccQAIX
+					HRACFx4hAhcfAgFHDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3878,7 +5095,15 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxwgAUcdAQFHHhcBRx+QAXcc8AF3HQABdx4AAXcfQAGHHDABhx0QAYcegQGHHwQBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIXHEACFx0QAhceIQIXHwQBRwwC</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					AAE3H0ABRxwgAUcdAQFHHhcBRx+QAXcc8AF3
+					HQABdx4AAXcfQAGHHDABhx0QAYcegQGHHwQB
+					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
+					AacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIX
+					HEACFx0QAhceIQIXHwQBRwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3896,7 +5121,12 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAF3HCABdx0BAXceFwF3H5ABhxwwAYcdEAGHHqsBhx8DAaccQAGnHRABpx6LAacfAwIXHFACFx0QAhceKwIXHwMBRwwCAXcMAgGnDAICFwwC</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAF3HCABdx0BAXce
+					FwF3H5ABhxwwAYcdEAGHHqsBhx8DAaccQAGn
+					HRABpx6LAacfAwIXHFACFx0QAhceKwIXHwMB
+					RwwCAXcMAgGnDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3914,7 +5144,15 @@
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAXccIAF3HQEBdx4XAXcfkAGHHDABhx0QAYcegQGHHwMBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIXHEACFx0QAhceIQIXHwMBdwwC</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfkAE3HPABNx0AATce
+					AAE3H0ABRxzwAUcdAAFHHgABRx9AAXccIAF3
+					HQEBdx4XAXcfkAGHHDABhx0QAYcegQGHHwMB
+					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
+					AacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
+					AAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIX
+					HEACFx0QAhceIQIXHwMBdwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3932,7 +5170,11 @@
 					<key>CodecID</key>
 					<integer>283902617</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQEBJx6gAScfkAFHHBABRx0BAUceFwFHH5ABlxwwAZcdEAGXHoEBlx8EAhccIAIXHRACFx4hAhcfBAFHDAICFwwC</data>
+					<data>
+					ASccQAEnHQEBJx6gAScfkAFHHBABRx0BAUce
+					FwFHH5ABlxwwAZcdEAGXHoEBlx8EAhccIAIX
+					HRACFx4hAhcfBAFHDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3950,7 +5192,11 @@
 					<key>CodecID</key>
 					<integer>283902617</integer>
 					<key>ConfigData</key>
-					<data>ASccQAEnHQEBJx6gAScfkAF3HBABdx0BAXceFwF3H5ABlxwwAZcdEAGXHoEBlx8EAhccIAIXHRACFx4hAhcfBA==</data>
+					<data>
+					ASccQAEnHQEBJx6gAScfkAF3HBABdx0BAXce
+					FwF3H5ABlxwwAZcdEAGXHoEBlx8EAhccIAIX
+					HRACFx4hAhcfBA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3964,7 +5210,12 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAGHHCABhx2QAYceoAGHH5AB5xwwAecdYQHnHksB5x8BAaccQAGnHTABpx6BAacfAQG3HFABtx1AAbceIQG3HwEBlxxgAZcdkAGXHoEBlx8C</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAGHHCABhx2QAYce
+					oAGHH5AB5xwwAecdYQHnHksB5x8BAaccQAGn
+					HTABpx6BAacfAQG3HFABtx1AAbceIQG3HwEB
+					lxxgAZcdkAGXHoEBlx8C
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3978,7 +5229,14 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -3992,7 +5250,12 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfASGHHCAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHqEhlx8CIaccQCGnHTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIh5xwwIecdYSHnHksh5x8B</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfASGHHCAhhx2QIYce
+					oCGHH5AhlxxgIZcdkCGXHqEhlx8CIaccQCGn
+					HTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIh
+					5xwwIecdYSHnHksh5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4006,7 +5269,12 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfASGHHCAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHqEhlx8CIaccQCGnHTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIh5xwwIecdYSHnHksh5x8B</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfASGHHCAhhx2QIYce
+					oCGHH5AhlxxgIZcdkCGXHqEhlx8CIaccQCGn
+					HTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIh
+					5xwwIecdYSHnHksh5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4020,7 +5288,15 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>AUccMAFHHQEBRx4QAUcfkAG3HEABtx0AAbceIQG3HwEBlxwQAZcdAQGXHqABlx+QAYccIAGHHQABhx6BAYcfAQFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAacc8AGnHQABpx4AAacfQAHHHPABxx0AAcceAAHHH0AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFHDAI=</data>
+					<data>
+					AUccMAFHHQEBRx4QAUcfkAG3HEABtx0AAbce
+					IQG3HwEBlxwQAZcdAQGXHqABlx+QAYccIAGH
+					HQABhx6BAYcfAQFXHPABVx0AAVceAAFXH0AB
+					ZxzwAWcdAAFnHgABZx9AAacc8AGnHQABpx4A
+					AacfQAHHHPABxx0AAcceAAHHH0AB1xzwAdcd
+					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAFH
+					DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4038,7 +5314,12 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>AbccEAG3HUABtx4hAbcfAAG3DAIBRxwgAUcdAAFHHhcBRx+QAUcMAgGHHDABhx2QAYcegQGHHwABJxxAAScdAAEnHqYBJx+QAeccYAHnHWAB5x5LAecfAQ==</data>
+					<data>
+					AbccEAG3HUABtx4hAbcfAAG3DAIBRxwgAUcd
+					AAFHHhcBRx+QAUcMAgGHHDABhx2QAYcegQGH
+					HwABJxxAAScdAAEnHqYBJx+QAeccYAHnHWAB
+					5x5LAecfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4056,7 +5337,12 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>AZccEAGXHZEBlx6gAZcfkQFHHCABRx1AAUceIQFHHwEBVxwwAVcdQQFXHhEBVx8BAYccQAGHHZABhx6BAYcfAQG3HFABtx1AAbceIQG3HwIB5xxgAecdYAHnHksB5x8B</data>
+					<data>
+					AZccEAGXHZEBlx6gAZcfkQFHHCABRx1AAUce
+					IQFHHwEBVxwwAVcdQQFXHhEBVx8BAYccQAGH
+					HZABhx6BAYcfAQG3HFABtx1AAbceIQG3HwIB
+					5xxgAecdYAHnHksB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4074,7 +5360,11 @@
 					<key>CodecID</key>
 					<integer>283903586</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4hAUcfAQFXHCABVx0AAVceEwFXH5ABtxwwAbcdEAG3HiEBtx8BAYccQAGHHTABhx6hAYcfkAGXHFABlx0QAZcegQGXHwI=</data>
+					<data>
+					AUccEAFHHUABRx4hAUcfAQFXHCABVx0AAVce
+					EwFXH5ABtxwwAbcdEAG3HiEBtx8BAYccQAGH
+					HTABhx6hAYcfkAGXHFABlx0QAZcegQGXHwI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4088,7 +5378,10 @@
 					<key>CodecID</key>
 					<integer>283903587</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUceEwFHH5ACFxwwAhcdEAIXHiECFx8CAUcMAg==</data>
+					<data>
+					ASccEAEnHQABJx6gAScfkAFHHCABRx0AAUce
+					EwFHH5ACFxwwAhcdEAIXHiECFx8CAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4106,7 +5399,12 @@
 					<key>CodecID</key>
 					<integer>283903587</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAGHHCABhx0QAYcegQGHHwIBlxwwAZcdAAGXHqABlx+QAdccQAHXHYAB1x4FAdcfQAHnHFAB5x0QAeceRQHnHwACFxxgAhcdEAIXHiECFx8BAUcMAg==</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAGHHCABhx0QAYce
+					gQGHHwIBlxwwAZcdAAGXHqABlx+QAdccQAHX
+					HYAB1x4FAdcfQAHnHFAB5x0QAeceRQHnHwAC
+					FxxgAhcdEAIXHiECFx8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4124,7 +5422,13 @@
 					<key>CodecID</key>
 					<integer>283903587</integer>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4BIUcfASF3HCAhdx0AIXceEyF3H5AhFxwwIRcdYCEXHkQhFx8BIeccQCHnHRAh5x5WIecfECGHHFAhhx0AIYceoCGHH5AhlxxgIZcdACGXHqAhlx+QIacccCGnHTAhpx6BIacfASIXHJAiFx1AIhceISIXHwE=</data>
+					<data>
+					IUccECFHHUAhRx4BIUcfASF3HCAhdx0AIXce
+					EyF3H5AhFxwwIRcdYCEXHkQhFx8BIeccQCHn
+					HRAh5x5WIecfECGHHFAhhx0AIYceoCGHH5Ah
+					lxxgIZcdACGXHqAhlx+QIacccCGnHTAhpx6B
+					IacfASIXHJAiFx1AIhceISIXHwE=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4140,7 +5444,12 @@
 					<key>Comment</key>
 					<string>Custom ALC663 for Asus N56/76 by m-dudarev</string>
 					<key>ConfigData</key>
-					<data>AZccEAGXHQABlx6gAZcfkAGHHCABhx0QAYcegQGHHwIBRxwwAUcdAAFHHhABRx+QAUcMAgIXHEACFx0QAhceIQIXHwIBFxzwARcdAAEXHgABFx9AAecc8AHnHQAB5x4AAecfQA==</data>
+					<data>
+					AZccEAGXHQABlx6gAZcfkAGHHCABhx0QAYce
+					gQGHHwIBRxwwAUcdAAFHHhABRx+QAUcMAgIX
+					HEACFx0QAhceIQIXHwIBFxzwARcdAAEXHgAB
+					Fx9AAecc8AHnHQAB5x4AAecfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4160,7 +5469,13 @@
 					<key>Comment</key>
 					<string>Custom by alex1960 for ASUS N71J</string>
 					<key>ConfigData</key>
-					<data>AUccAAFHHQEBRx4TAUcfmQA3HBAANx0AADceVgA3HxgCFxwgAhcdQAIXHiECFx8BAbccMAG3HUABtx4hAbcfAQHnHEAB5x0BAeceQwHnH5kBhxxQAYcdCQGHHqMBhx+ZAZccYAGXHZwBlx6BAZcfAQF3HPABdx0BAXceEwF3H5k=</data>
+					<data>
+					AUccAAFHHQEBRx4TAUcfmQA3HBAANx0AADce
+					VgA3HxgCFxwgAhcdQAIXHiECFx8BAbccMAG3
+					HUABtx4hAbcfAQHnHEAB5x0BAeceQwHnH5kB
+					hxxQAYcdCQGHHqMBhx+ZAZccYAGXHZwBlx6B
+					AZcfAQF3HPABdx0BAXceEwF3H5k=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4174,7 +5489,12 @@
 					<key>CodecID</key>
 					<integer>283903589</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfmQGnHCABpx0QAacegQGnH5MBVxxAAVcdAQFXHhMBVx+ZAZccUAGXHRABlx4hAZcfAwG3HGABtx0QAbceIQG3HwMB5xxwAecdEAHnHkUB5x8D</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfmQGnHCABpx0QAace
+					gQGnH5MBVxxAAVcdAQFXHhMBVx+ZAZccUAGX
+					HRABlx4hAZcfAwG3HGABtx0QAbceIQG3HwMB
+					5xxwAecdEAHnHkUB5x8D
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4188,7 +5508,12 @@
 					<key>CodecID</key>
 					<integer>283903589</integer>
 					<key>ConfigData</key>
-					<data>ASccUAEnHQABJx6gAScfkAFXHBABVx0AAVceEwFXH5ABVwwCAZccIAGXHRABlx4hAZcfAAGnHEABpx0QAacegQGnHwABtxxgAbcdEAG3HiEBtx8AAdcc8AHXHQAB1x6DAdcfUA==</data>
+					<data>
+					ASccUAEnHQABJx6gAScfkAFXHBABVx0AAVce
+					EwFXH5ABVwwCAZccIAGXHRABlx4hAZcfAAGn
+					HEABpx0QAacegQGnHwABtxxgAbcdEAG3HiEB
+					tx8AAdcc8AHXHQAB1x6DAdcfUA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4202,7 +5527,12 @@
 					<key>Comment</key>
 					<string>ALC668 Mirone Laptop Patch</string>
 					<key>ConfigData</key>
-					<data>ABJxwQAScdAAEnHqABJx+QAUccIAFHHQABRx4XAUcfkAFXHDABVx0QAVceIQFXHwEBZxxAAWcdAAFnHgABZx9AAbccUAG3HRABtx6BAbcfAgHXHGAB1x0AAdcewAHXH0ABRwwA==</data>
+					<data>
+					ABJxwQAScdAAEnHqABJx+QAUccIAFHHQABRx
+					4XAUcfkAFXHDABVx0QAVceIQFXHwEBZxxAAW
+					cdAAFnHgABZx9AAbccUAG3HRABtx6BAbcfAg
+					HXHGAB1x0AAdcewAHXH0ABRwwA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4216,7 +5546,11 @@
 					<key>Comment</key>
 					<string>Custom ALC668 by lazzy for laptop ASUS G551JM</string>
 					<key>ConfigData</key>
-					<data>ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUceFwFHH5ABVxwgAVcdEAFXHiEBVx8AAbccQAG3HRABtx6BAbcfAAFHDAI=</data>
+					<data>
+					ASccMAEnHQABJx6gAScfkAFHHBABRx0AAUce
+					FwFHH5ABVxwgAVcdEAFXHiEBVx8AAbccQAG3
+					HRABtx6BAbcfAAFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4234,7 +5568,33 @@
 					<key>Comment</key>
 					<string>ALC668 syscl Laptop Patch (DELL Precision M3800)</string>
 					<key>ConfigData</key>
-					<data>ASccAQEnHQEBJx6gAScfkAFHHAIBRx0BAUceFwFHH5ABRwwCAVccAwFXHRABVx4rAVcfAwFXDAIBZxzwAWcdAAFnHgABZx9AAYcc8AGHHQABhx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzwAacdAAGnHgABpx9AAbccBAG3HRABtx6LAbcfAwHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIFAAECBL6+AgUAAgIEqqoCBQADAgQAAAIFAAQCBAGAAgUABgIEAAACBQAHAgQPgAIFAAgCBAAxAgUACgIEAGACBQALAgQAAAIFAAwCBHz3AgUADQIEEIACBQAOAgR/fwIFAA8CBMzMAgUAEAIE3cwCBQARAgQAAQIFABMCBAAAAgUAFAIEKqACBQAXAgSpQAIFABkCBAAAAgUAGgIEAAACBQAbAgQAAAIFABwCBAAAAgUAHQIEAAACBQAeAgR0GAIFAB8CBAgEAgUAIAIEQgACBQAhAgQEaAIFACICBIzMAgUAIwIEAlACBQAkAgR0GAIFACcCBAAAAgUAKAIEjMwCBQAqAgT/AAIFACsCBIAAAgUApwIE/wACBQCoAgSAAAIFAKoCBC4XAgUAqwIEoMACBQCsAgQAAAIFAK0CBAAAAgUArgIEKsYCBQCvAgSkgAIFALACBAAAAgUAsQIEAAACBQCyAgQAAAIFALMCBAAAAgUAtAIEAAACBQC1AgQQQAIFALYCBNaXAgUAtwIEkCsCBQC4AgTWlwIFALkCBJArAgUAugIEuLoCBQC7AgSqqwIFALwCBKqvAgUAvQIEaqoCBQC+AgQcAgIFAMACBAD/AgUAwQIED6Y=</data>
+					<data>
+					ASccAQEnHQEBJx6gAScfkAFHHAIBRx0BAUce
+					FwFHH5ABRwwCAVccAwFXHRABVx4rAVcfAwFX
+					DAIBZxzwAWcdAAFnHgABZx9AAYcc8AGHHQAB
+					hx4AAYcfQAGXHPABlx0AAZceAAGXH0ABpxzw
+					AacdAAGnHgABpx9AAbccBAG3HRABtx6LAbcf
+					AwHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHn
+					HgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIFAAEC
+					BL6+AgUAAgIEqqoCBQADAgQAAAIFAAQCBAGA
+					AgUABgIEAAACBQAHAgQPgAIFAAgCBAAxAgUA
+					CgIEAGACBQALAgQAAAIFAAwCBHz3AgUADQIE
+					EIACBQAOAgR/fwIFAA8CBMzMAgUAEAIE3cwC
+					BQARAgQAAQIFABMCBAAAAgUAFAIEKqACBQAX
+					AgSpQAIFABkCBAAAAgUAGgIEAAACBQAbAgQA
+					AAIFABwCBAAAAgUAHQIEAAACBQAeAgR0GAIF
+					AB8CBAgEAgUAIAIEQgACBQAhAgQEaAIFACIC
+					BIzMAgUAIwIEAlACBQAkAgR0GAIFACcCBAAA
+					AgUAKAIEjMwCBQAqAgT/AAIFACsCBIAAAgUA
+					pwIE/wACBQCoAgSAAAIFAKoCBC4XAgUAqwIE
+					oMACBQCsAgQAAAIFAK0CBAAAAgUArgIEKsYC
+					BQCvAgSkgAIFALACBAAAAgUAsQIEAAACBQCy
+					AgQAAAIFALMCBAAAAgUAtAIEAAACBQC1AgQQ
+					QAIFALYCBNaXAgUAtwIEkCsCBQC4AgTWlwIF
+					ALkCBJArAgUAugIEuLoCBQC7AgSqqwIFALwC
+					BKqvAgUAvQIEaqoCBQC+AgQcAgIFAMACBAD/
+					AgUAwQIED6Y=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4252,7 +5612,12 @@
 					<key>Comment</key>
 					<string>ALC668 Mirone Laptop Patch (Asus N750Jk)</string>
 					<key>ConfigData</key>
-					<data>ABJxwQAScdAAEnHqABJx+QAUccIAFHHQABRx4XAUcfkAFXHDABVx0QAVceIQFXHwEBZxxAAWcdAAFnHgABZx9AAbccUAG3HRABtx6BAbcfAgHXHGAB1x0AAdcewAHXH0ABRwwA==</data>
+					<data>
+					ABJxwQAScdAAEnHqABJx+QAUccIAFHHQABRx
+					4XAUcfkAFXHDABVx0QAVceIQFXHwEBZxxAAW
+					cdAAFnHgABZx9AAbccUAG3HRABtx6BAbcfAg
+					HXHGAB1x0AAdcewAHXH0ABRwwA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4266,7 +5631,15 @@
 					<key>Comment</key>
 					<string>ALC668 Custom (Asus N750JV)</string>
 					<key>ConfigData</key>
-					<data>ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUceFwFHH5ABVxwfAVcdEAFXHiEBVx8DAWcc8AFnHQABZx4AAWcfQAGHHPABhx0AAYceAAGHH0ABlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HDABtx0QAbcegQG3HwMB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAH3HPAB9x0AAfceAAH3H0ABRwwCAVcMAg==</data>
+					<data>
+					ASccAAEnHQEBJx6mAScfkAFHHBABRx0BAUce
+					FwFHH5ABVxwfAVcdEAFXHiEBVx8DAWcc8AFn
+					HQABZx4AAWcfQAGHHPABhx0AAYceAAGHH0AB
+					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
+					AacfQAG3HDABtx0QAbcegQG3HwMB1xzwAdcd
+					AAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAH3
+					HPAB9x0AAfceAAH3H0ABRwwCAVcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4284,7 +5657,17 @@
 					<key>Comment</key>
 					<string>Custom ALC670 by Alex Auditore</string>
 					<key>ConfigData</key>
-					<data>AbccQAG3HRABtx4rAbcfAQFXHDABVx0BAVceEwFXH5ABJxwQAScdAQEnHqABJx+QAaccUAGnHTEBpx6BAacfAQGXHCABlx2QAZcegQGXHwEB5xxgAecdEQHnHksB5x8BARcc8AEXHQABFx4AARcfQAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAdcc8AHXHQAB1x4AAdcfQAIXHPACFx0AAhceAAIXH0A=</data>
+					<data>
+					AbccQAG3HRABtx4rAbcfAQFXHDABVx0BAVce
+					EwFXH5ABJxwQAScdAQEnHqABJx+QAaccUAGn
+					HTEBpx6BAacfAQGXHCABlx2QAZcegQGXHwEB
+					5xxgAecdEQHnHksB5x8BARcc8AEXHQABFx4A
+					ARcfQAE3HPABNx0AATceAAE3H0ABRxzwAUcd
+					AAFHHgABRx9AAWcc8AFnHQABZx4AAWcfQAF3
+					HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgAB
+					hx9AAdcc8AHXHQAB1x4AAdcfQAIXHPACFx0A
+					AhceAAIXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4298,7 +5681,10 @@
 					<key>Comment</key>
 					<string>MacPeet - ALC671 for Fujitsu-Siemens D3433-S (Q170 chip)</string>
 					<key>ConfigData</key>
-					<data>AYccIAGHHTABhx6BAYcfAQIXHDACFx1AAhceAQIXHwECFwwC</data>
+					<data>
+					AYccIAGHHTABhx6BAYcfAQIXHDACFx1AAhce
+					AQIXHwECFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4312,7 +5698,12 @@
 					<key>Comment</key>
 					<string>MacPeet - ALC671 for Fujitsu  Esprimo C720</string>
 					<key>ConfigData</key>
-					<data>IXccECF3HQAhdx4TIXcfkCFHHCAhRx0QIUceISFHHwIhRwwCIhccMCIXHUAiFx4RIhcfkSIXDAIhlxxQIZcdECGXHoEhlx8CIYccYCGHHTAhhx6BIYcfAQ==</data>
+					<data>
+					IXccECF3HQAhdx4TIXcfkCFHHCAhRx0QIUce
+					ISFHHwIhRwwCIhccMCIXHUAiFx4RIhcfkSIX
+					DAIhlxxQIZcdECGXHoEhlx8CIYccYCGHHTAh
+					hx6BIYcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4348,7 +5739,12 @@
 					<key>CodecID</key>
 					<integer>283904130</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
+					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
+					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
+					5xyQAecd4AHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4362,7 +5758,14 @@
 					<key>CodecID</key>
 					<integer>283904130</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4378,7 +5781,14 @@
 					<key>Comment</key>
 					<string>Mirone - Realtek ALC883 by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4392,7 +5802,15 @@
 					<key>Comment</key>
 					<string>toleda ALC885</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfASFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfccoCH3HQEh9x7LIfcfASEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfASFXHCAhVx0QIVce
+					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
+					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
+					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfccoCH3HQEh9x7LIfcfASEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4408,7 +5826,15 @@
 					<key>Comment</key>
 					<string>Custom ALC885 by alex1960</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfASFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfccoCH3HQEh9x7LIfcfASEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfASFXHCAhVx0QIVce
+					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
+					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
+					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfccoCH3HQEh9x7LIfcfASEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4424,7 +5850,14 @@
 					<key>Comment</key>
 					<string>MacPeet - ALC885 for GA-G33M-DS2R</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkSFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIYccQCGHHZAhhx6gIYcfkCGnHFAhpx0wIacegSGnHwEhlxxgIZcdkCGXHoEhlx8CIbcccCG3HUAhtx4hIbcfAiHnHJAh5x1hIeceSyHnHwEh9xygIfcdASH3Hssh9x8B</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkSFXHCAhVx0QIVce
+					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIYccQCGH
+					HZAhhx6gIYcfkCGnHFAhpx0wIacegSGnHwEh
+					lxxgIZcdkCGXHoEhlx8CIbcccCG3HUAhtx4h
+					IbcfAiHnHJAh5x1hIeceSyHnHwEh9xygIfcd
+					ASH3Hssh9x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4438,7 +5871,15 @@
 					<key>Comment</key>
 					<string>Toleda ALC887</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
+					ECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3
+					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
+					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
+					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
+					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
+					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4456,7 +5897,15 @@
 					<key>Comment</key>
 					<string>Toleda ALC887</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcdACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEhhx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0QIaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcd
+					ACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
+					HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEh
+					hx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0Q
+					IaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
+					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
+					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4474,7 +5923,15 @@
 					<key>Comment</key>
 					<string>Toleda ALC887</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
+					ECFXHgEhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
+					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
+					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
+					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
+					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
+					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4492,7 +5949,12 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
+					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
+					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB
+					5xyQAecdYAHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4510,7 +5972,14 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4528,7 +5997,11 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkQFHDAIBtxwgAbcdQAG3HiEBtx8CAbcMAgGHHDABhx2QAYceoQGHH5EBlxxAAZcdkQGXHoEBlx+SAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkQFHDAIBtxwgAbcd
+					QAG3HiEBtx8CAbcMAgGHHDABhx2QAYceoQGH
+					H5EBlxxAAZcdkQGXHoEBlx+SAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4546,7 +6019,12 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>AbccAAG3HUABtx4hAbcfAQGHHBABhx2QAYceoAGHH5EBlxwgAZcdkAGXHoEBlx8BAUccMAFHHUABRx4RAUcfkQGnHEABpx0wAacegQGnHwEB5xxQAecdYQHnHksB5x8BAUcMAg==</data>
+					<data>
+					AbccAAG3HUABtx4hAbcfAQGHHBABhx2QAYce
+					oAGHH5EBlxwgAZcdkAGXHoEBlx8BAUccMAFH
+					HUABRx4RAUcfkQGnHEABpx0wAacegQGnHwEB
+					5xxQAecdYQHnHksB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4564,7 +6042,13 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhhxxAIYcdkCGHHqAhhx+QIaccUCGnHTAhpx6BIacfASGXHGAhlx2QIZcegSGXHwIhtxxwIbcdQCG3HiEhtx8CIecckCHnHWEh5x5LIecfAQ==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
+					ASFXHwEhhxxAIYcdkCGHHqAhhx+QIaccUCGn
+					HTAhpx6BIacfASGXHGAhlx2QIZcegSGXHwIh
+					txxwIbcdQCG3HiEhtx8CIecckCHnHWEh5x5L
+					IecfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4578,7 +6062,12 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkSFHDAIhhxxAIYcdYCGHHgEhhx8BIaccUCGnHRAhpx4BIacfASGXHGAhlx2QIZceoSGXH5EhtxxwIbcdQCG3HiEhtx8CIecckCHnHWEh5x5LIecfAQ==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkSFHDAIhhxxAIYcd
+					YCGHHgEhhx8BIaccUCGnHRAhpx4BIacfASGX
+					HGAhlx2QIZceoSGXH5EhtxxwIbcdQCG3HiEh
+					tx8CIecckCHnHWEh5x5LIecfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4592,7 +6081,14 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>AUccAAFHHUABRx4BAUcfAQFnHBABZx1gAWceAQFnHwEBVxwgAVcdEAFXHgEBVx8BAXccMAF3HSABdx4BAXcfAQG3HEABtx1AAbceIQG3HwIBFxxQARcdAQEXHkYBFx+ZAYccYAGHHZABhx6gAYcfkAGnHHABpx0wAacegQGnHwEBlxyAAZcdkAGXHoEBlx8CAUcMAg==</data>
+					<data>
+					AUccAAFHHUABRx4BAUcfAQFnHBABZx1gAWce
+					AQFnHwEBVxwgAVcdEAFXHgEBVx8BAXccMAF3
+					HSABdx4BAXcfAQG3HEABtx1AAbceIQG3HwIB
+					FxxQARcdAQEXHkYBFx+ZAYccYAGHHZABhx6g
+					AYcfkAGnHHABpx0wAacegQGnHwEBlxyAAZcd
+					kAGXHoEBlx8CAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4610,7 +6106,17 @@
 					<key>Comment</key>
 					<string>Custom by klblk ALC887 for GA-Q87TN</string>
 					<key>ConfigData</key>
-					<data>IRcc8CEXHQAhFx4AIRcfQCEnHPAhJx0AISceACEnH0AhRxzwIUcdACFHHgAhRx9AIVcc8CFXHQAhVx4AIVcfQCFnHPAhZx0AIWceACFnH0AhdxzwIXcdACF3HgAhdx9AIYcccCGHHZAhhx6BIYcfASGXHPAhlx0AIZceACGXH0AhpxwgIacdQCGnHgEhpx8BIbcc8CG3HQAhtx4AIbcfQCHHHPAhxx0AIcceACHHH0Ah1xzwIdcdACHXHgAh1x9AIecc8CHnHQAh5x4AIecfQCH3HPAh9x0AIfceACH3H0A=</data>
+					<data>
+					IRcc8CEXHQAhFx4AIRcfQCEnHPAhJx0AISce
+					ACEnH0AhRxzwIUcdACFHHgAhRx9AIVcc8CFX
+					HQAhVx4AIVcfQCFnHPAhZx0AIWceACFnH0Ah
+					dxzwIXcdACF3HgAhdx9AIYcccCGHHZAhhx6B
+					IYcfASGXHPAhlx0AIZceACGXH0AhpxwgIacd
+					QCGnHgEhpx8BIbcc8CG3HQAhtx4AIbcfQCHH
+					HPAhxx0AIcceACHHH0Ah1xzwIdcdACHXHgAh
+					1x9AIecc8CHnHQAh5x4AIecfQCH3HPAh9x0A
+					IfceACH3H0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4624,7 +6130,12 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>AUccAAFHHUABRx4BAUcfAQG3HBABtx1AAbceIQG3HwIBhxwgAYcdkAGHHqABhx+QAaccMAGnHTABpx6BAacfAQGXHEABlx2QAZcegQGXHwIBRwwC</data>
+					<data>
+					AUccAAFHHUABRx4BAUcfAQG3HBABtx1AAbce
+					IQG3HwIBhxwgAYcdkAGHHqABhx+QAaccMAGn
+					HTABpx6BAacfAQGXHEABlx2QAZcegQGXHwIB
+					RwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4642,7 +6153,11 @@
 					<key>Comment</key>
 					<string>0th3r ALC887 for PRIME B250-PLUS</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4BAUcfAQG3HCABtx1BAbceIQG3HwIBhxxAAYcdkAGHHoEBhx8BAZccUAGXHZEBlx6BAZcfAg==</data>
+					<data>
+					AUccEAFHHUABRx4BAUcfAQG3HCABtx1BAbce
+					IQG3HwIBhxxAAYcdkAGHHoEBhx8BAZccUAGX
+					HZEBlx6BAZcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4656,7 +6171,12 @@
 					<key>Comment</key>
 					<string>ALC887 for Asus PRIME Z270-P (full Rear and Front, non auto-switch) by ctich</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4BAUcfAQFHDAIBtxwgAbcdQAG3HiEBtx8CAbcMAgEXHDABFx0BARceRgEXH5ABhxxAAYcdkAGHHqABhx+RAaccTwGnHTABpx6BAacfAQGXHFABlx2RAZcegQGXHwI=</data>
+					<data>
+					AUccEAFHHUABRx4BAUcfAQFHDAIBtxwgAbcd
+					QAG3HiEBtx8CAbcMAgEXHDABFx0BARceRgEX
+					H5ABhxxAAYcdkAGHHqABhx+RAaccTwGnHTAB
+					px6BAacfAQGXHFABlx2RAZcegQGXHwI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4674,7 +6194,12 @@
 					<key>Comment</key>
 					<string>ALC887 for Asus PRIME Z270-P (Rear LineOut1, Mic - LineOut2, LineIn - LineOut3 - 5.1 and Front, non auto-switch) by ctich</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4BAUcfAQFHDAIBhxwQAYcdYAGHHgEBhx8BAaccEAGnHRABpx4BAacfAQG3HCABtx1AAbceIQG3HwIBtwwCARccMAEXHQEBFx5GARcfkAGXHFABlx2RAZcegQGXHwI=</data>
+					<data>
+					AUccEAFHHUABRx4BAUcfAQFHDAIBhxwQAYcd
+					YAGHHgEBhx8BAaccEAGnHRABpx4BAacfAQG3
+					HCABtx1AAbceIQG3HwIBtwwCARccMAEXHQEB
+					Fx5GARcfkAGXHFABlx2RAZcegQGXHwI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4692,7 +6217,17 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>IRccYCEXHQEhFx5DIRcfmSEnHPAhJx0AISceACEnH0AhRxyAIUcdQCFHHhEhRx8BIUcMAiFXHIIhVx0QIVceASFXHwEhZxyBIWcdYCFnHgEhZx8BIXccgiF3HSAhdx4BIXcfASGHHHAhhx2QIYceoSGHHwEhlxxwIZcdkCGXHqEhlx8CIaccICGnHTAhpx6BIacfASG3HFAhtx1AIbceISG3HwIhtwwCIccc8CHHHQAhxx4AIccfQCHXHPAh1x0AIdceACHXH0Ah5xzwIecdACHnHgAh5x9AIfcc8CH3HQAh9x4AIfcfQA==</data>
+					<data>
+					IRccYCEXHQEhFx5DIRcfmSEnHPAhJx0AISce
+					ACEnH0AhRxyAIUcdQCFHHhEhRx8BIUcMAiFX
+					HIIhVx0QIVceASFXHwEhZxyBIWcdYCFnHgEh
+					Zx8BIXccgiF3HSAhdx4BIXcfASGHHHAhhx2Q
+					IYceoSGHHwEhlxxwIZcdkCGXHqEhlx8CIacc
+					ICGnHTAhpx6BIacfASG3HFAhtx1AIbceISG3
+					HwIhtwwCIccc8CHHHQAhxx4AIccfQCHXHPAh
+					1x0AIdceACHXH0Ah5xzwIecdACHnHgAh5x9A
+					Ifcc8CH3HQAh9x4AIfcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4706,7 +6241,12 @@
 					<key>CodecID</key>
 					<integer>283904135</integer>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfASGHHFAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIacccCGnHTAhpx6BIacfASG3HIAhtx1AIbceISG3HwIh5xyQIecdYCHnHkUh5x8B</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfASGHHFAhhx2QIYce
+					oCGHH5AhlxxgIZcdkCGXHoEhlx8CIacccCGn
+					HTAhpx6BIacfASG3HIAhtx1AIbceISG3HwIh
+					5xyQIecdYCHnHkUh5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4720,7 +6260,15 @@
 					<key>Comment</key>
 					<string>toleda ALC888</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
+					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
+					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
+					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4734,7 +6282,15 @@
 					<key>Comment</key>
 					<string>toleda ALC888</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFXHPAhVx0AIVceACFXH0AhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx1gIYceASGHHwEhlxxgIZcdkCGXHqAhlx+QIaccUCGnHRAhpx4BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFXHPAhVx0AIVce
+					ACFXH0AhZxzwIWcdACFnHgAhZx9AIXcc8CF3
+					HQAhdx4AIXcfQCGHHEAhhx1gIYceASGHHwEh
+					lxxgIZcdkCGXHqAhlx+QIaccUCGnHRAhpx4B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4748,7 +6304,15 @@
 					<key>Comment</key>
 					<string>toleda ALC888</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
+					ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3
+					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
+					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4762,7 +6326,13 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQABJx6gAScfmQFHHCABRx1AAUceIQFHHwEBtxwwAbcdAQG3HhMBtx+ZAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYcegQGHHwEBpxxgAacdMAGnHoEBpx8BAecccAHnHUAB5x5FAecfAQFHDAI=</data>
+					<data>
+					ASccEAEnHQABJx6gAScfmQFHHCABRx1AAUce
+					IQFHHwEBtxwwAbcdAQG3HhMBtx+ZAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYcegQGHHwEB
+					pxxgAacdMAGnHoEBpx8BAecccAHnHUAB5x5F
+					AecfAQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4780,7 +6350,12 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
+					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
+					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
+					5xyQAecd4AHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4794,7 +6369,14 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4808,7 +6390,12 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHRABRx4hAUcfAQFHDAIBhxwwAYcdEAGHHqEBhx8BASccQAEnHQABJx6jAScfkAF3HFABdx0AAXceEwF3H5ABpxxgAacdEAGnHoEBpx8BAecccAHnHRAB5x5FAecfAQ==</data>
+					<data>
+					AUccEAFHHRABRx4hAUcfAQFHDAIBhxwwAYcd
+					EAGHHqEBhx8BASccQAEnHQABJx6jAScfkAF3
+					HFABdx0AAXceEwF3H5ABpxxgAacdEAGnHoEB
+					px8BAecccAHnHRAB5x5FAecfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4826,7 +6413,12 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAFHDAIBJxxAAScdAAEnHqMBJx+QAVccUAFXHRABVx4hAVcfAAFXDAIBpxxgAacdMAGnHoEBpx8AAecccAHnHRAB5x5FAecfAA==</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAFHDAIBJxxAAScd
+					AAEnHqMBJx+QAVccUAFXHRABVx4hAVcfAAFX
+					DAIBpxxgAacdMAGnHoEBpx8AAecccAHnHRAB
+					5x5FAecfAA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4840,7 +6432,13 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAFHDAIBdxwgAXcdAAF3HhMBdx+QAeccMAHnHRAB5x5EAecfAAGHHEABhx0QAYceoQGHHwABJxxQAScdAAEnHqMBJx+QAaccYAGnHRABpx6BAacfAAG3HHABtx0QAbceIQG3HwA=</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAFHDAIBdxwgAXcd
+					AAF3HhMBdx+QAeccMAHnHRAB5x5EAecfAAGH
+					HEABhx0QAYceoQGHHwABJxxQAScdAAEnHqMB
+					Jx+QAaccYAGnHRABpx6BAacfAAG3HHABtx0Q
+					AbceIQG3HwA=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4858,7 +6456,12 @@
 					<key>CodecID</key>
 					<integer>283904136</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQABRx4TAUcfkAFHDAIBdxwgAXcdEAF3HhMBdx+QAeccMAHnHRAB5x5FAecfAAGXHEABlx0AAZceowGXH5ABhxxQAYcdEAGHHoEBhx8AAVccYAFXHRABVx4hAVcfAAFXDAI=</data>
+					<data>
+					AUccEAFHHQABRx4TAUcfkAFHDAIBdxwgAXcd
+					EAF3HhMBdx+QAeccMAHnHRAB5x5FAecfAAGX
+					HEABlx0AAZceowGXH5ABhxxQAYcdEAGHHoEB
+					hx8AAVccYAFXHRABVx4hAVcfAAFXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4876,7 +6479,15 @@
 					<key>Comment</key>
 					<string>ALC889, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
+					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
+					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
+					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4890,7 +6501,15 @@
 					<key>Comment</key>
 					<string>ALC889, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
+					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
+					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
+					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4904,7 +6523,15 @@
 					<key>Comment</key>
 					<string>ALC889, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
+					ASFXHwEhZxwwIWcdYCFnHgEhZx8BIXcc8CF3
+					ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3
+					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4918,7 +6545,12 @@
 					<key>Comment</key>
 					<string>MacPeet ALC889 Medion P4020 D</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4hAUcfAQFHDAIBtxwgAbcdAAG3HhMBtx+QAeccMAHnHWAB5x5EAecfAQGXHFABlx0AAZceowGXH5ABpxxgAacdMAGnHoEBpx8B</data>
+					<data>
+					AUccEAFHHUABRx4hAUcfAQFHDAIBtxwgAbcd
+					AAG3HhMBtx+QAeccMAHnHWAB5x5EAecfAQGX
+					HFABlx0AAZceowGXH5ABpxxgAacdMAGnHoEB
+					px8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4936,7 +6568,17 @@
 					<key>Comment</key>
 					<string>alc889, Custom by Sergey_Galan</string>
 					<key>ConfigData</key>
-					<data>IRcc8CEXHQAhFx4AIRcfQCEnHPAhJx0AISceACEnH0AhRxwwIUcdQSFHHhEhRx8BIVcc8CFXHQAhVx4AIVcfQCFnHPAhZx0AIWceACFnH0AhdxzwIXcdACF3HgAhdx9AIYccECGHHZEhhx6gIYcfkCGXHCAhlx2QIZcegSGXHwEhpxzwIacdACGnHgAhpx9AIbccgCG3HUAhtx4hIbcfASHHHPAhxx0AIcceACHHH0Ah1xzwIdcdACHXHgAh1x9AIecckCHnHSEh5x5LIecfASH3HPAh9x0AIfceACH3H0A=</data>
+					<data>
+					IRcc8CEXHQAhFx4AIRcfQCEnHPAhJx0AISce
+					ACEnH0AhRxwwIUcdQSFHHhEhRx8BIVcc8CFX
+					HQAhVx4AIVcfQCFnHPAhZx0AIWceACFnH0Ah
+					dxzwIXcdACF3HgAhdx9AIYccECGHHZEhhx6g
+					IYcfkCGXHCAhlx2QIZcegSGXHwEhpxzwIacd
+					ACGnHgAhpx9AIbccgCG3HUAhtx4hIbcfASHH
+					HPAhxx0AIcceACHHH0Ah1xzwIdcdACHXHgAh
+					1x9AIecckCHnHSEh5x5LIecfASH3HPAh9x0A
+					IfceACH3H0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4950,7 +6592,11 @@
 					<key>CodecID</key>
 					<integer>283904103</integer>
 					<key>ConfigData</key>
-					<data>AXccIAF3HRABdx4hAXcfAgGHHDABhx2QAYcegQGHHwEBtxxAAbcdMAG3HoEBtx8BAhccYAIXHQACFx4RAhcfAAIXDAI=</data>
+					<data>
+					AXccIAF3HRABdx4hAXcfAgGHHDABhx2QAYce
+					gQGHHwEBtxxAAbcdMAG3HoEBtx8BAhccYAIX
+					HQACFx4RAhcfAAIXDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4964,7 +6610,12 @@
 					<key>CodecID</key>
 					<integer>283904103</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HUABdx4hAXcfAQFnHDABZx0wAWcegQFnHwEBhxxAAYcdkAGHHqEBhx+RAaccYAGnHZABpx6BAacfAgHnHHAB5x0AAeceRgHnH5ACFxyAAhcdQAIXHhECFx8B</data>
+					<data>
+					AXccEAF3HUABdx4hAXcfAQFnHDABZx0wAWce
+					gQFnHwEBhxxAAYcdkAGHHqEBhx+RAaccYAGn
+					HZABpx6BAacfAgHnHHAB5x0AAeceRgHnH5AC
+					FxyAAhcdQAIXHhECFx8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4978,7 +6629,15 @@
 					<key>Comment</key>
 					<string>ALC892, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
+					ECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3
+					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
+					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
+					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
+					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
+					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -4996,7 +6655,15 @@
 					<key>Comment</key>
 					<string>ALC892, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcdACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEhhx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0QIaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcd
+					ACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
+					HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEh
+					hx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0Q
+					IaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
+					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
+					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5014,7 +6681,15 @@
 					<key>Comment</key>
 					<string>ALC892, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
+					ECFXHgEhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
+					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
+					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
+					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
+					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
+					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5032,7 +6707,13 @@
 					<key>CodecID</key>
 					<integer>283904146</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHZABJx6gAScfmQFHHCABRx1AAUceIQFHHwEBdxwwAXcdEAF3HgEBdx8BAYccQAGHHZABhx6BAYcfAQGnHFABpx0wAacegQGnHwEBtxxgAbcdQAG3HhMBtx+ZAecccAHnHWAB5x5FAecfAQG3DAI=</data>
+					<data>
+					ASccEAEnHZABJx6gAScfmQFHHCABRx1AAUce
+					IQFHHwEBdxwwAXcdEAF3HgEBdx8BAYccQAGH
+					HZABhx6BAYcfAQGnHFABpx0wAacegQGnHwEB
+					txxgAbcdQAG3HhMBtx+ZAecccAHnHWAB5x5F
+					AecfAQG3DAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5046,7 +6727,12 @@
 					<key>Comment</key>
 					<string>ALC892, Mirone</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
+					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
+					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
+					5xyQAecd4AHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5060,7 +6746,14 @@
 					<key>Comment</key>
 					<string>ALC892, Mirone</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5092,7 +6785,14 @@
 					<key>Comment</key>
 					<string>MacPeet - alc892 for MSi Z97S SLI Krait Edition</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkQG3HCABRwwCAbcdQAG3HiEBtx8CAbcMAgGHHDABhx2QAYceoQGHH5EBVxxQAVcdEAFXHgEBVx8BAWccYAFnHWABZx4BAWcfAQF3HHABdx0gAXceAQF3HwEBlxyAAZcdkAGXHoEBlx8CAacckAGnHTABpx6BAacfAQ==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkQG3HCABRwwCAbcd
+					QAG3HiEBtx8CAbcMAgGHHDABhx2QAYceoQGH
+					H5EBVxxQAVcdEAFXHgEBVx8BAWccYAFnHWAB
+					Zx4BAWcfAQF3HHABdx0gAXceAQF3HwEBlxyA
+					AZcdkAGXHoEBlx8CAacckAGnHTABpx6BAacf
+					AQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5110,7 +6810,12 @@
 					<key>Comment</key>
 					<string>MacPeet - alc892 for MSI GL73-8RD</string>
 					<key>ConfigData</key>
-					<data>AUccIAFHHXABRx4hAUcfAAFHDAIBVxwwAVcdAAFXHhcBVx+QAeccQAHnHXAB5x5FAecfAAEnHFABJx0AAScepgEnH5ABhxxgAYcdcAGHHoEBhx8AAXcccAF3HQABdx4XAXcfkA==</data>
+					<data>
+					AUccIAFHHXABRx4hAUcfAAFHDAIBVxwwAVcd
+					AAFXHhcBVx+QAeccQAHnHXAB5x5FAecfAAEn
+					HFABJx0AAScepgEnH5ABhxxgAYcdcAGHHoEB
+					hx8AAXcccAF3HQABdx4XAXcfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5128,7 +6833,14 @@
 					<key>Comment</key>
 					<string>MacPeet - alc892 for MSI B150M MORTAR - SwitchMode</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBtxwgAbcdQAG3HiEBtx8CAbcMAgFXHDABVx0QAVceAQFXHwEBlxxQAZcdkAGXHoEBlx8CAWcccAFnHWABZx4BAWcfAQGHHIABhx2QAYceoAGHH5ABpxyQAacdMAGnHoEBpx8BAeccsAHnHRAB5x5FAecfAQ==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBtxwgAbcd
+					QAG3HiEBtx8CAbcMAgFXHDABVx0QAVceAQFX
+					HwEBlxxQAZcdkAGXHoEBlx8CAWcccAFnHWAB
+					Zx4BAWcfAQGHHIABhx2QAYceoAGHH5ABpxyQ
+					AacdMAGnHoEBpx8BAeccsAHnHRAB5x5FAecf
+					AQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5146,7 +6858,14 @@
 					<key>Comment</key>
 					<string>MacPeet - alc892 for MSI B150M MORTAR - ManualMode</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4BAUcfAQFHDAIBtxwgAbcdQAG3HiEBtx8CAbcMAgFXHDABVx0QAVceAQFXHwEBlxxQAZcdkAGXHoEBlx8CAWcccAFnHWABZx4BAWcfAQGHHIABhx2QAYceoAGHH5ABpxyQAacdMAGnHoEBpx8BAeccsAHnHRAB5x5FAecfAQ==</data>
+					<data>
+					AUccEAFHHUABRx4BAUcfAQFHDAIBtxwgAbcd
+					QAG3HiEBtx8CAbcMAgFXHDABVx0QAVceAQFX
+					HwEBlxxQAZcdkAGXHoEBlx8CAWcccAFnHWAB
+					Zx4BAWcfAQGHHIABhx2QAYceoAGHH5ABpxyQ
+					AacdMAGnHoEBpx8BAeccsAHnHRAB5x5FAecf
+					AQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5164,7 +6883,13 @@
 					<key>Comment</key>
 					<string>ALC892 for Clevo P751DMG by Cryse Hillmes</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUceFwFHH5ABdxxgAXcdEAF3HgEBdx8BAYccgAGHHRABhx6BAYcfAQGnHCABpx0QAacegQGnHwEBtxxQAbcdEAG3HiEBtx8BAecccAHnHRAB5x5FAecfAQFHDAI=</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfkAFHHEABRx0BAUce
+					FwFHH5ABdxxgAXcdEAF3HgEBdx8BAYccgAGH
+					HRABhx6BAYcfAQGnHCABpx0QAacegQGnHwEB
+					txxQAbcdEAG3HiEBtx8BAecccAHnHRAB5x5F
+					AecfAQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5182,7 +6907,17 @@
 					<key>Comment</key>
 					<string>ALC892 for Clevo P65xSE/SA by Derek Zhu</string>
 					<key>ConfigData</key>
-					<data>ASccEAEnHZEBJx6mAScfkAGHHCABhx1gAYcegQGHHwEBRxwwAUcdAQFHHhcBRx+QAbccQAG3HTABtx4hAbcfAQF3HFABdx1AAXceAQF3HwEB5xxgAecdYQHnHkUB5x8BALcccAC3HREAtx4WALcfkAFXHPABVx0AAVceAAFXHwQBZxzwAWcdAAFnHgABZx8EAZcc8AGXHQABlx4AAZcfBAGnHPABpx0AAaceAAGnHwQBxxzwAccdAAHHHgABxx8EAdcc8AHXHQAB1x4AAdcfBAH3HPAB9x0AAfceAAH3HwQBRwwCAbcMAg==</data>
+					<data>
+					ASccEAEnHZEBJx6mAScfkAGHHCABhx1gAYce
+					gQGHHwEBRxwwAUcdAQFHHhcBRx+QAbccQAG3
+					HTABtx4hAbcfAQF3HFABdx1AAXceAQF3HwEB
+					5xxgAecdYQHnHkUB5x8BALcccAC3HREAtx4W
+					ALcfkAFXHPABVx0AAVceAAFXHwQBZxzwAWcd
+					AAFnHgABZx8EAZcc8AGXHQABlx4AAZcfBAGn
+					HPABpx0AAaceAAGnHwQBxxzwAccdAAHHHgAB
+					xx8EAdcc8AHXHQAB1x4AAdcfBAH3HPAB9x0A
+					AfceAAH3HwQBRwwCAbcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5200,7 +6935,17 @@
 					<key>Comment</key>
 					<string>Custom ALC892 for GIGABYTE B360 M AORUS PRO</string>
 					<key>ConfigData</key>
-					<data>ARccMAEXHQEBFx5DARcfmQEnHPABJx0AASceAAEnH0ABRxxAAUcdQQFHHhEBRx+RAUcMAgFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAXccgAF3HSABdx4BAXcfAQGHHBABhx2RAYceoQGHH5EBlxxyAZcdEAGXHqEBlx8CAacc8AGnHQABpx4AAacfQAG3HFIBtx0QAbceIQG3HwIBtwwCAccc8AHHHQABxx4AAccfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQA==</data>
+					<data>
+					ARccMAEXHQEBFx5DARcfmQEnHPABJx0AASce
+					AAEnH0ABRxxAAUcdQQFHHhEBRx+RAUcMAgFX
+					HPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgAB
+					Zx9AAXccgAF3HSABdx4BAXcfAQGHHBABhx2R
+					AYceoQGHH5EBlxxyAZcdEAGXHqEBlx8CAacc
+					8AGnHQABpx4AAacfQAG3HFIBtx0QAbceIQG3
+					HwIBtwwCAccc8AHHHQABxx4AAccfQAHXHPAB
+					1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9A
+					Afcc8AH3HQAB9x4AAfcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5218,7 +6963,16 @@
 					<key>Comment</key>
 					<string>Custom ALC892 for GA-Z87-HD3 by BIM167</string>
 					<key>ConfigData</key>
-					<data>IRccUCEXHXEhFx5EIRcfASEnHPAhJx0AISceACEnH0AhRxwQIUcdQCFHHhEhRx+QIVccICFXHRAhVx4BIVcfASFnHDAhZx1gIWceASFnHwEhdxzwIXcdACF3HgAhdx9AIYccYCGHHZAhhx6gIYcfkCGXHIAhlx2QIZcegSGXHwIhpxxwIacdMCGnHoEhpx8BIbccQCG3HUAhtx4hIbcfAiHHHPAhxx0AIcceACHHH0Ah5xzwIecdACHnHgAh5x9AIfcckCH3HXEh9x7EIfcfAQ==</data>
+					<data>
+					IRccUCEXHXEhFx5EIRcfASEnHPAhJx0AISce
+					ACEnH0AhRxwQIUcdQCFHHhEhRx+QIVccICFX
+					HRAhVx4BIVcfASFnHDAhZx1gIWceASFnHwEh
+					dxzwIXcdACF3HgAhdx9AIYccYCGHHZAhhx6g
+					IYcfkCGXHIAhlx2QIZcegSGXHwIhpxxwIacd
+					MCGnHoEhpx8BIbccQCG3HUAhtx4hIbcfAiHH
+					HPAhxx0AIcceACHHH0Ah5xzwIecdACHnHgAh
+					5x9AIfcckCH3HXEh9x7EIfcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5232,7 +6986,17 @@
 					<key>Comment</key>
 					<string>Custom ALC892 for HASEE K770e i7 D1 by gitawake</string>
 					<key>ConfigData</key>
-					<data>ARcc8AEXHQABFx4AARcfQAEnHFABJx0BAScepgEnH5ABRxwQAUcdAQFHHhcBRx+QAUcMAgFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAXccIAF3HRABdx4BAXcfAQGHHGABhx0QAYcegQGHHwEBlxzwAZcdAAGXHgABlx9AAaccUAGnHRABpx6BAacfAQG3HDABtx0QAbceIQG3HwEBtwwCAccc8AHHHQABxx4AAccfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQA==</data>
+					<data>
+					ARcc8AEXHQABFx4AARcfQAEnHFABJx0BASce
+					pgEnH5ABRxwQAUcdAQFHHhcBRx+QAUcMAgFX
+					HPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgAB
+					Zx9AAXccIAF3HRABdx4BAXcfAQGHHGABhx0Q
+					AYcegQGHHwEBlxzwAZcdAAGXHgABlx9AAacc
+					UAGnHRABpx6BAacfAQG3HDABtx0QAbceIQG3
+					HwEBtwwCAccc8AHHHQABxx4AAccfQAHXHPAB
+					1x0AAdceAAHXH0AB5xzwAecdAAHnHgAB5x9A
+					Afcc8AH3HQAB9x4AAfcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5246,7 +7010,12 @@
 					<key>Comment</key>
 					<string>ALC892 with working SPDIF</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
+					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
+					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
+					5xyQAecd4AHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5260,7 +7029,12 @@
 					<key>Comment</key>
 					<string>Custom ALC892 DNS P150EM by Constanta</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHHABhx2QAYcegQGHHwEBlxxgAZcdAQGXHqABlx+QAaccgAGnHTABpx6BAacfAQG3HCABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8B</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHHABhx2QAYce
+					gQGHHwEBlxxgAZcdAQGXHqABlx+QAaccgAGn
+					HTABpx6BAacfAQG3HCABtx1AAbceIQG3HwEB
+					5xyQAecd4AHnHkUB5x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5274,7 +7048,15 @@
 					<key>Comment</key>
 					<string>ALC898, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcdECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAhhx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0wIacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFHDAIhVxwgIVcd
+					ECFXHgEhVx8BIWccMCFnHWAhZx4BIWcfASF3
+					HPAhdx0AIXceACF3H0AhhxxAIYcdkCGHHqAh
+					hx+QIZccYCGXHZAhlx6BIZcfAiGnHFAhpx0w
+					IacegSGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
+					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
+					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5288,7 +7070,15 @@
 					<key>Comment</key>
 					<string>ALC898, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcdACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEhhx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0QIaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcMAiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFHDAIhVxzwIVcd
+					ACFXHgAhVx9AIWcc8CFnHQAhZx4AIWcfQCF3
+					HPAhdx0AIXceACF3H0AhhxxAIYcdYCGHHgEh
+					hx8BIZccYCGXHZAhlx6gIZcfkCGnHFAhpx0Q
+					IaceASGnHwEhtxxwIbcdQCG3HiEhtx8CIbcM
+					AiHnHJAh5x1hIeceSyHnHwEh9xzwIfcdACH3
+					HgAh9x9AIRcc8CEXHQAhFx4AIRcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5302,7 +7092,15 @@
 					<key>Comment</key>
 					<string>ALC898, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
+					ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3
+					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
+					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5316,7 +7114,12 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
+					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
+					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
+					5xyQAecd4AHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5334,7 +7137,14 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5352,7 +7162,17 @@
 					<key>Comment</key>
 					<string>Custom ALC898 by Irving23 for MSI GT72S 6QF-065CN</string>
 					<key>ConfigData</key>
-					<data>ARcc8AEXHQABFx4AARcfQAEnHBABJx0BASceoAEnH5ABRxzwAUcdAAFHHgABRx9AAVcc8AFXHQABVx4AAVcfQAFnHPABZx0AAWceAAFnH0ABdxxgAXcdEAF3HgEBdx8BAYccEAGHHRABhx6hAYcfAQGXHEABlx0BAZceFwGXH5ABpxwgAacdEAGnHoEBpx8BAbccQAG3HQEBtx4XAbcfkAHHHPABxx0AAcceAAHHH0AB1xzwAdcdAAHXHgAB1x9AAecccAHnHREB5x5FAecfAQH3HPAB9x0AAfceAAH3H0ABRwwC</data>
+					<data>
+					ARcc8AEXHQABFx4AARcfQAEnHBABJx0BASce
+					oAEnH5ABRxzwAUcdAAFHHgABRx9AAVcc8AFX
+					HQABVx4AAVcfQAFnHPABZx0AAWceAAFnH0AB
+					dxxgAXcdEAF3HgEBdx8BAYccEAGHHRABhx6h
+					AYcfAQGXHEABlx0BAZceFwGXH5ABpxwgAacd
+					EAGnHoEBpx8BAbccQAG3HQEBtx4XAbcfkAHH
+					HPABxx0AAcceAAHHH0AB1xzwAdcdAAHXHgAB
+					1x9AAecccAHnHREB5x5FAecfAQH3HPAB9x0A
+					AfceAAH3H0ABRwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5370,7 +7190,11 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>AaccEAGnHQABpx4XAacfkAHnHCAB5x0QAeceRgHnHwEBhxwwAYcdEAGHHoEBhx8BASccQAEnHQABJx6gAScfkA==</data>
+					<data>
+					AaccEAGnHQABpx4XAacfkAHnHCAB5x0QAece
+					RgHnHwEBhxwwAYcdEAGHHoEBhx8BASccQAEn
+					HQABJx6gAScfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5384,7 +7208,15 @@
 					<key>Comment</key>
 					<string>ALC898, Toleda</string>
 					<key>ConfigData</key>
-					<data>IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVceASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5AhlxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6BIacfASG3HHAhtx1AIbceISG3HwIh5xyQIecdYSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEXHPAhFx0AIRceACEXH0A=</data>
+					<data>
+					IUccECFHHUAhRx4RIUcfkCFXHCAhVx0QIVce
+					ASFXHwEhZxzwIWcdACFnHgAhZx9AIXcc8CF3
+					HQAhdx4AIXcfQCGHHEAhhx2QIYceoCGHH5Ah
+					lxxgIZcdkCGXHoEhlx8CIaccUCGnHTAhpx6B
+					IacfASG3HHAhtx1AIbceISG3HwIh5xyQIecd
+					YSHnHksh5x8BIfcc8CH3HQAh9x4AIfcfQCEX
+					HPAhFx0AIRceACEXH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5398,7 +7230,13 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>ARcc8AEXHQABFx4AARcfQAEnHFABJx0BAScepgEnH5ABRxwQAUcdAQFHHhcBRx+QAXccIAF3HRABdx4BAXcfAQGHHEABhx0QAYcegQGHHwEB1xzwAdcdAAHXHgAB1x9AAeccMAHnHREB5x5EAecfAQFHDAI=</data>
+					<data>
+					ARcc8AEXHQABFx4AARcfQAEnHFABJx0BASce
+					pgEnH5ABRxwQAUcdAQFHHhcBRx+QAXccIAF3
+					HRABdx4BAXcfAQGHHEABhx0QAYcegQGHHwEB
+					1xzwAdcdAAHXHgAB1x9AAeccMAHnHREB5x5E
+					AecfAQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5416,7 +7254,13 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>ARcc8AEXHQABFx4AARcfQAEnHFABJx0BAScepgEnH5ABRxwQAUcdAQFHHhcBRx+QAXccIAF3HRABdx4BAXcfAQGHHEABhx0QAYcegQGHHwEBpxxgAacdEAGnHoEBpx8BAdcc8AHXHQAB1x4AAdcfQAHnHDAB5x0RAeceRAHnHwEBRwwC</data>
+					<data>
+					ARcc8AEXHQABFx4AARcfQAEnHFABJx0BASce
+					pgEnH5ABRxwQAUcdAQFHHhcBRx+QAXccIAF3
+					HRABdx4BAXcfAQGHHEABhx0QAYcegQGHHwEB
+					pxxgAacdEAGnHoEBpx8BAdcc8AHXHQAB1x4A
+					AdcfQAHnHDAB5x0RAeceRAHnHwEBRwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5434,7 +7278,13 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6gAScfmQGHHCABhx0QAYcegQGHHwIBVxwwAVcdAQFXHhMBVx+ZAaccMQGnHQEBpx4TAacfmQG3HDIBtx0BAbceEwG3H5kBtwwCAUccQAFHHRABRx4hAUcfAgFHDAIB5xxQAecdEQHnHkUB5x8C</data>
+					<data>
+					ASccEAEnHQEBJx6gAScfmQGHHCABhx0QAYce
+					gQGHHwIBVxwwAVcdAQFXHhMBVx+ZAaccMQGn
+					HQEBpx4TAacfmQG3HDIBtx0BAbceEwG3H5kB
+					twwCAUccQAFHHRABRx4hAUcfAgFHDAIB5xxQ
+					AecdEQHnHkUB5x8C
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5452,7 +7302,17 @@
 					<key>CodecID</key>
 					<integer>283904153</integer>
 					<key>ConfigData</key>
-					<data>ARcc8AEXHQABFx4AARcfQAEnHBABJx0BASceoAEnH5ABRxxQAUcdQAFHHiEBRx8BAUcMAgFXHEABVx0BAVceEAFXH5ABZxzwAWcdAAFnHgABZx9AAXcc8AF3HQABdx4AAXcfQAGHHCABhx2QAYcegQGHHwEBlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3H0ABxxzwAccdAAHHHgABxx9AAdcc8AHXHQAB1x4AAdcfQAHnHHAB5x1BAeceRQHnHwEB9xzwAfcdAAH3HgAB9x9A</data>
+					<data>
+					ARcc8AEXHQABFx4AARcfQAEnHBABJx0BASce
+					oAEnH5ABRxxQAUcdQAFHHiEBRx8BAUcMAgFX
+					HEABVx0BAVceEAFXH5ABZxzwAWcdAAFnHgAB
+					Zx9AAXcc8AF3HQABdx4AAXcfQAGHHCABhx2Q
+					AYcegQGHHwEBlxzwAZcdAAGXHgABlx9AAacc
+					8AGnHQABpx4AAacfQAG3HPABtx0AAbceAAG3
+					H0ABxxzwAccdAAHHHgABxx9AAdcc8AHXHQAB
+					1x4AAdcfQAHnHHAB5x1BAeceRQHnHwEB9xzw
+					AfcdAAH3HgAB9x9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5470,7 +7330,15 @@
 					<key>Comment</key>
 					<string>ALC898, 4 Line Out by Andrey1970</string>
 					<key>ConfigData</key>
-					<data>AUccAAFHHUABRx4RAUcfkAFXHBABVx0QAVceAQFXHwEBZxwgAWcdYAFnHgEBZx8BAYccMAGHHZABhx6gAYcfkAGnHEABpx0wAacegQGnHwEBlxxQAZcdkAGXHoEBlx8CAbccYAG3HUABtx4hAbcfAgHnHHAB5x1hAeceSwHnHwEBdxyAAXcdIAF3HgEBdx8BAfcc8AH3HQAB9x4AAfcfSQEXHPABFx0AARceAAEXH0k=</data>
+					<data>
+					AUccAAFHHUABRx4RAUcfkAFXHBABVx0QAVce
+					AQFXHwEBZxwgAWcdYAFnHgEBZx8BAYccMAGH
+					HZABhx6gAYcfkAGnHEABpx0wAacegQGnHwEB
+					lxxQAZcdkAGXHoEBlx8CAbccYAG3HUABtx4h
+					AbcfAgHnHHAB5x1hAeceSwHnHwEBdxyAAXcd
+					IAF3HgEBdx8BAfcc8AH3HQAB9x4AAfcfSQEX
+					HPABFx0AARceAAEXH0k=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5484,7 +7352,15 @@
 					<key>Comment</key>
 					<string>toleda - ALC1150 </string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
+					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
+					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
+					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
+					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5502,7 +7378,15 @@
 					<key>Comment</key>
 					<string>toleda - ALC1150 </string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEBhx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0QAaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
+					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEB
+					hx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0Q
+					AaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
+					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5520,7 +7404,15 @@
 					<key>Comment</key>
 					<string>toleda - ALC1150 </string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
+					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
+					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
+					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
+					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5538,7 +7430,12 @@
 					<key>CodecID</key>
 					<integer>283904256</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
+					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
+					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
+					5xyQAecd4AHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5556,7 +7453,14 @@
 					<key>CodecID</key>
 					<integer>283904256</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5574,7 +7478,14 @@
 					<key>CodecID</key>
 					<integer>283904256</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5592,7 +7503,14 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwE=</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
+					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
+					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
+					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwE=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5610,7 +7528,14 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEBhx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0QAaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwE=</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
+					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEB
+					hx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0Q
+					AaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwE=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5628,7 +7553,15 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
+					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
+					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
+					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
+					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5646,7 +7579,12 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
+					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
+					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
+					5xyQAecd4AHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5664,7 +7602,14 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC1220</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5682,7 +7627,13 @@
 					<key>CodecName</key>
 					<string>Custom Realtek ALC1220 by truesoldier</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAG3HCABtx1AAbceIQG3HwIB5xwwAecdIAHnHksB5x8BAYccQAGHHZABhx6gAYcfkAGXHFABlx2QAZcegQGXHwIBVxxwAVcdEAFXHgEBVx8BAWccgAFnHWABZx4BAWcfAQGnHKABpx0wAacegQGnHwE=</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAG3HCABtx1AAbce
+					IQG3HwIB5xwwAecdIAHnHksB5x8BAYccQAGH
+					HZABhx6gAYcfkAGXHFABlx2QAZcegQGXHwIB
+					VxxwAVcdEAFXHgEBVx8BAWccgAFnHWABZx4B
+					AWcfAQGnHKABpx0wAacegQGnHwE=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5696,7 +7647,12 @@
 					<key>CodecName</key>
 					<string>MacPeet - ALC1220 for Clevo P950HR</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHRABRx4hAUcfAQFHDAIBJxwwAScdAAEnHqYBJx+ZAYccQAGHHRABhx6BAYcfAQG3HGABtx0AAbceFwG3H5kBtwwCAecccAHnHRAB5x5EAecfAQ==</data>
+					<data>
+					AUccEAFHHRABRx4hAUcfAQFHDAIBJxwwAScd
+					AAEnHqYBJx+ZAYccQAGHHRABhx6BAYcfAQG3
+					HGABtx0AAbceFwG3H5kBtwwCAecccAHnHRAB
+					5x5EAecfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5710,7 +7666,12 @@
 					<key>CodecName</key>
 					<string>fleaplus - ALC1220 for MSI WT75</string>
 					<key>ConfigData</key>
-					<data>AbccIAG3HQEBtx4XAbcfkAG3DAIBhxxAAYcdEAGHHqEBhx8BAZccQQGXHRQBlx6BAZcfAQGnHE8Bpx0QAacegQGnHwEBJxxQAScdAQEnHmABJx+Q</data>
+					<data>
+					AbccIAG3HQEBtx4XAbcfkAG3DAIBhxxAAYcd
+					EAGHHqEBhx8BAZccQQGXHRQBlx6BAZcfAQGn
+					HE8Bpx0QAacegQGnHwEBJxxQAScdAQEnHmAB
+					Jx+Q
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5728,7 +7689,14 @@
 					<key>CodecName</key>
 					<string>MacPeet - ALC1220 for Gigabyte Z390</string>
 					<key>ConfigData</key>
-					<data>AeccMAHnHSAB5x5FAecfAQGHHEABhx2QAYceoQGHH5EBlxxQAZcdkAGXHoEBlx8CAUccYAFHHUABRx4hAUcfAgFHDAIBVxxwAVcdEAFXHgEBVx8BAWccgAFnHWABZx4BAWcfAQGnHJABpx0wAacegQGnHwEBtxygAbcdQAG3HhEBtx+RAbcMAg==</data>
+					<data>
+					AeccMAHnHSAB5x5FAecfAQGHHEABhx2QAYce
+					oQGHH5EBlxxQAZcdkAGXHoEBlx8CAUccYAFH
+					HUABRx4hAUcfAgFHDAIBVxxwAVcdEAFXHgEB
+					Vx8BAWccgAFnHWABZx4BAWcfAQGnHJABpx0w
+					AacegQGnHwEBtxygAbcdQAG3HhEBtx+RAbcM
+					Ag==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5746,7 +7714,12 @@
 					<key>CodecName</key>
 					<string>ALC1220 for MSI GE63 Raider RGB 8RF</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQEnHCABJx0BASceoAEnH5ABlxwwAZcdEAGXHoEBlx8CAbccgAG3HUABtx4hAbcfAQHnHJAB5x3gAeceRQHnHwEBRwwC</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQEnHCABJx0BASce
+					oAEnH5ABlxwwAZcdEAGXHoEBlx8CAbccgAG3
+					HUABtx4hAbcfAQHnHJAB5x3gAeceRQHnHwEB
+					RwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5764,7 +7737,15 @@
 					<key>CodecName</key>
 					<string>lostwolf - ALC1220 for Gigabyte Z370-HD3P</string>
 					<key>ConfigData</key>
-					<data>AScc8AEnHQABJx4AAScfQAFHHBABRx1AAUceEQFHHwEBRwwCAVccIAFXHRABVx4BAVcfAQFnHDABZx1gAWceAQFnHwEBdxxAAXcdIAF3HgEBdx8BAYccUAGHHZABhx6gAYcfkQGXHGABlx2QAZcegAGXHwIBpxxwAacdMAGnHoEBpx8BAbccgAG3HUABtx4hAbcfAgG3DAIB1xzwAdcdAAHXHgAB1x9AAecckAHnHQAB5x5DAecfmQ==</data>
+					<data>
+					AScc8AEnHQABJx4AAScfQAFHHBABRx1AAUce
+					EQFHHwEBRwwCAVccIAFXHRABVx4BAVcfAQFn
+					HDABZx1gAWceAQFnHwEBdxxAAXcdIAF3HgEB
+					dx8BAYccUAGHHZABhx6gAYcfkQGXHGABlx2Q
+					AZcegAGXHwIBpxxwAacdMAGnHoEBpx8BAbcc
+					gAG3HUABtx4hAbcfAgG3DAIB1xzwAdcdAAHX
+					HgAB1x9AAecckAHnHQAB5x5DAecfmQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5782,7 +7763,14 @@
 					<key>CodecName</key>
 					<string>MacPeet- ALC1220 for Z390 Aorus Ultra - Output SP/HP Manualmode </string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwE=</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
+					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
+					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
+					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwE=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5800,7 +7788,14 @@
 					<key>CodecName</key>
 					<string>MacPeet- ALC1220 for Z390 Aorus Ultra - Output SP/HP SwitchMode</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwE=</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
+					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
+					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
+					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwE=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5818,7 +7813,14 @@
 					<key>CodecName</key>
 					<string>MacPeet- ALC1220 for Z370 AORUS Gaming 7 - Output SP/HP SwitchMode</string>
 					<key>ConfigData</key>
-					<data>AeccMAHnHSAB5x5FAecfAQGHHEABhx2QAYceoQGHH5ABlxxQAZcdkAGXHoEBlx8CAUccYAFHHUABRx4hAUcfAgFHDAIBVxxwAVcdEAFXHgEBVx8BAWccgAFnHWABZx4BAWcfAQGnHJABpx0wAacegQGnHwEBtxygAbcdQAG3HhEBtx+QAbcMAg==</data>
+					<data>
+					AeccMAHnHSAB5x5FAecfAQGHHEABhx2QAYce
+					oQGHH5ABlxxQAZcdkAGXHoEBlx8CAUccYAFH
+					HUABRx4hAUcfAgFHDAIBVxxwAVcdEAFXHgEB
+					Vx8BAWccgAFnHWABZx4BAWcfAQGnHJABpx0w
+					AacegQGnHwEBtxygAbcdQAG3HhEBtx+QAbcM
+					Ag==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5836,7 +7838,11 @@
 					<key>CodecName</key>
 					<string>Custom ALC1220 for MSI P65 Creator by CleverCoder</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHRABRx4RAUcfAAFHDAIBtxwgAbcdAAG3HhcBtx+QAbcMAgGXHDABlx0QAZcegQGXHwABJxxAAScdAAEnHqYBJx+Q</data>
+					<data>
+					AUccEAFHHRABRx4RAUcfAAFHDAIBtxwgAbcd
+					AAG3HhcBtx+QAbcMAgGXHDABlx0QAZcegQGX
+					HwABJxxAAScdAAEnHqYBJx+Q
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5854,7 +7860,11 @@
 					<key>CodecName</key>
 					<string>MiBook 2019 by Dynamix1997</string>
 					<key>ConfigData</key>
-					<data>AaccEAGnHQEBpx4QAacfkAFHHCABRx0QAUceIQFHHwMBRwwCASccMAEnHQEBJx6mAScfkAGHHEABhx0QAYcegQGHHwM=</data>
+					<data>
+					AaccEAGnHQEBpx4QAacfkAFHHCABRx0QAUce
+					IQFHHwMBRwwCASccMAEnHQEBJx6mAScfkAGH
+					HEABhx0QAYcegQGHHwM=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5870,7 +7880,14 @@
 					<key>CodecName</key>
 					<string>toleda -  Realtek ALCS1200A</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXcc8AF3HQABdx4AAXcfQAGHHEABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAaccUAGnHTABpx6BAacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecdYQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXcc8AF3
+					HQABdx4AAXcfQAGHHEABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAaccUAGnHTABpx6B
+					AacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecd
+					YQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5886,7 +7903,14 @@
 					<key>CodecName</key>
 					<string>toleda -  Realtek ALCS1200A</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAXcc8AF3HQABdx4AAXcfQAGHHEABhx1gAYceAQGHHwEBlxxgAZcdkAGXHqABlx+QAaccUAGnHRABpx4BAacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecdYQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFXHPABVx0AAVce
+					AAFXH0ABZxzwAWcdAAFnHgABZx9AAXcc8AF3
+					HQABdx4AAXcfQAGHHEABhx1gAYceAQGHHwEB
+					lxxgAZcdkAGXHqABlx+QAaccUAGnHRABpx4B
+					AacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecd
+					YQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5902,7 +7926,14 @@
 					<key>CodecName</key>
 					<string>toleda -  Realtek ALCS1200A</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFXHPABVx0AAVceAAFXH0ABZxzwAWcdAAFnHgABZx9AAXcc8AF3HQABdx4AAXcfQAGHHEABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAaccUAGnHTABpx6BAacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecdYQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFXHPABVx0AAVce
+					AAFXH0ABZxzwAWcdAAFnHgABZx9AAXcc8AF3
+					HQABdx4AAXcfQAGHHEABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAaccUAGnHTABpx6B
+					AacfAQG3HHABtx1AAbceIQG3HwIB5xyQAecd
+					YQHnHksB5x8BARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5920,7 +7951,15 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcdEAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxwgAVcd
+					EAFXHgEBVx8BAWccMAFnHWABZx4BAWcfAQF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
+					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
+					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
+					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5938,7 +7977,15 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEBhx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0QAaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
+					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdYAGHHgEB
+					hx8BAZccYAGXHZABlx6gAZcfkAGnHFABpx0Q
+					AaceAQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
+					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5956,7 +8003,15 @@
 					<key>CodecName</key>
 					<string>Toleda -  Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcdAAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqABhx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0wAacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcMAgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3HgAB9x9AARcc8AEXHQABFx4AARcfQA==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfkAFHDAIBVxzwAVcd
+					AAFXHgABVx9AAWcc8AFnHQABZx4AAWcfQAF3
+					HPABdx0AAXceAAF3H0ABhxxAAYcdkAGHHqAB
+					hx+QAZccYAGXHZABlx6BAZcfAgGnHFABpx0w
+					AacegQGnHwEBtxxwAbcdQAG3HiEBtx8CAbcM
+					AgHnHJAB5x1hAeceSwHnHwEB9xzwAfcdAAH3
+					HgAB9x9AARcc8AEXHQABFx4AARcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5974,7 +8029,12 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB5xyQAecd4AHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQGHHFABhx2QAYce
+					oAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGn
+					HTABpx6BAacfAQG3HIABtx1AAbceIQG3HwEB
+					5xyQAecd4AHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -5992,7 +8052,14 @@
 					<key>CodecName</key>
 					<string>Mirone - Realtek ALC S1220A</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5ABlxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6BAacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecdYAHnHkUB5x8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHCABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAXccQAF3
+					HSABdx4BAXcfAQGHHFABhx2QAYceoAGHH5AB
+					lxxgAZcdkAGXHoEBlx8CAacccAGnHTABpx6B
+					AacfAQG3HIABtx1AAbceIQG3HwIB5xyQAecd
+					YAHnHkUB5x8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6008,9 +8075,14 @@
 					<key>CodecID</key>
 					<integer>283906408</integer>
 					<key>CodecName</key>
-					<string>Realtek ALC S1220A Kushamot for Asus Z270G mb (based on Mirone&apos;s layout 7)</string>
+					<string>Realtek ALC S1220A Kushamot for Asus Z270G mb (based on Mirone's layout 7)</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4RAUcfAQFXHFABVx0QAVceAQFXHwEBZxwwAWcdYAFnHgEBZx8BAYccYAGHHZABhx6gAYcfkAGXHHABlx2QAZcegQGXHwEBtxwgAbcdQAG3HiEBtx8BAUcMAg==</data>
+					<data>
+					AUccEAFHHUABRx4RAUcfAQFXHFABVx0QAVce
+					AQFXHwEBZxwwAWcdYAFnHgEBZx8BAYccYAGH
+					HZABhx6gAYcfkAGXHHABlx2QAZcegQGXHwEB
+					txwgAbcdQAG3HiEBtx8BAUcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6064,7 +8136,11 @@
 					<key>CodecID</key>
 					<integer>351346546</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAaceoAGnH5ABlxwwAZcdEAGXHosBlx8BAWccQAFnHRABZx4rAWcfAQF3DAIBZwwC</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
+					oAGnH5ABlxwwAZcdEAGXHosBlx8BAWccQAFn
+					HRABZx4rAWcfAQF3DAIBZwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6078,7 +8154,11 @@
 					<key>CodecID</key>
 					<integer>351346546</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAaceoAGnH5ABlxwwAZcdEAGXHosBlx8BAWccQAFnHRABZx4rAWcfAQF3DAIBZwwCAZcHJAGnByQ=</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
+					oAGnH5ABlxwwAZcdEAGXHosBlx8BAWccQAFn
+					HRABZx4rAWcfAQF3DAIBZwwCAZcHJAGnByQ=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6096,7 +8176,11 @@
 					<key>CodecID</key>
 					<integer>351346566</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkQF3DAIBpxwgAacdAAGnHqYBpx+QAZccMAGXHRABlx6BAZcfAAFnHEABZx0QAWceIQFnHwABZwwC</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkQF3DAIBpxwgAacd
+					AAGnHqYBpx+QAZccMAGXHRABlx6BAZcfAAFn
+					HEABZx0QAWceIQFnHwABZwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6114,7 +8198,11 @@
 					<key>CodecID</key>
 					<integer>351346646</integer>
 					<key>ConfigData</key>
-					<data>AWccQAFnHRABZx4hAWcfBAGXHDABlx0QAZcegQGXHwQBpxwgAacdAQGnHqABpx+QAdccEAHXHQEB1x4XAdcfkAFnDAIB1wwC</data>
+					<data>
+					AWccQAFnHRABZx4hAWcfBAGXHDABlx0QAZce
+					gQGXHwQBpxwgAacdAQGnHqABpx+QAdccEAHX
+					HQEB1x4XAdcfkAFnDAIB1wwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6128,7 +8216,11 @@
 					<key>CodecID</key>
 					<integer>351346646</integer>
 					<key>ConfigData</key>
-					<data>AWccQAFnHRABZx4hAWcfBAGXHDABlx0QAZcegQGXHwQBpxwgAacdAQGnHqABpx+QAXccEAF3HQEBdx4XAXcfkAFnDAIBdwwC</data>
+					<data>
+					AWccQAFnHRABZx4hAWcfBAGXHDABlx0QAZce
+					gQGXHwQBpxwgAacdAQGnHqABpx+QAXccEAF3
+					HQEBdx4XAXcfkAFnDAIBdwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6142,7 +8234,11 @@
 					<key>CodecID</key>
 					<integer>351346696</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAaceoAGnH5ABlxwwAZcdEAGXHosBlx8BAdccQAHXHRAB1x4rAdcfAQF3DAIB1wwC</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
+					oAGnH5ABlxwwAZcdEAGXHosBlx8BAdccQAHX
+					HRAB1x4rAdcfAQF3DAIB1wwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6156,7 +8252,11 @@
 					<key>CodecID</key>
 					<integer>351346696</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkAF3DAIBpxwgAacdAAGnHqYBpx+QAZccMAGXHRABlx6BAZcfAAHXHEAB1x0QAdceIQHXHwAB1wwC</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkAF3DAIBpxwgAacd
+					AAGnHqYBpx+QAZccMAGXHRABlx6BAZcfAAHX
+					HEAB1x0QAdceIQHXHwAB1wwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6174,7 +8274,11 @@
 					<key>CodecID</key>
 					<integer>351346696</integer>
 					<key>ConfigData</key>
-					<data>AXccIAF3HQEBdx4XAXcfkAGXHDABlx0QAZcegQGXHwEBpxxAAacdAQGnHqABpx+QAWccEAFnHRABZx4hAWcfAQFnDAIBdwwC</data>
+					<data>
+					AXccIAF3HQEBdx4XAXcfkAGXHDABlx0QAZce
+					gQGXHwEBpxxAAacdAQGnHqABpx+QAWccEAFn
+					HRABZx4hAWcfAQFnDAIBdwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6192,7 +8296,11 @@
 					<key>CodecID</key>
 					<integer>351346696</integer>
 					<key>ConfigData</key>
-					<data>AWccUAFnHRABZx4hAWcfAQFnDAIBdxxAAXcdAQF3HhcBdx+RAXcMAgGXHHABlx0QAZcegQGXHwEBpxwQAacdAQGnHqYBpx+R</data>
+					<data>
+					AWccUAFnHRABZx4hAWcfAQFnDAIBdxxAAXcd
+					AQF3HhcBdx+RAXcMAgGXHHABlx0QAZcegQGX
+					HwEBpxwQAacdAQGnHqYBpx+R
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6210,7 +8318,15 @@
 					<key>CodecID</key>
 					<integer>351346896</integer>
 					<key>ConfigData</key>
-					<data>AWccEAFnHRABZx4hAWcfBAF3HPABdx0AAXceAAF3H0ABhxzwAYcdAAGHHgABhx9AAZccIAGXHRABlx6BAZcfBAGnHDABpx0BAacepgGnH5AB1xxAAdcdAQHXHhcB1x+ZAecc8AHnHQAB5x4AAecfQAH3HPAB9x0AAfceAAH3H0ACFxzwAhcdAAIXHgACFx9AAmcc8AJnHQACZx4AAmcfQAJ3HPACdx0AAnceAAJ3H0ABZwwCAdcMAg==</data>
+					<data>
+					AWccEAFnHRABZx4hAWcfBAF3HPABdx0AAXce
+					AAF3H0ABhxzwAYcdAAGHHgABhx9AAZccIAGX
+					HRABlx6BAZcfBAGnHDABpx0BAacepgGnH5AB
+					1xxAAdcdAQHXHhcB1x+ZAecc8AHnHQAB5x4A
+					AecfQAH3HPAB9x0AAfceAAH3H0ACFxzwAhcd
+					AAIXHgACFx9AAmcc8AJnHQACZx4AAmcfQAJ3
+					HPACdx0AAnceAAJ3H0ABZwwCAdcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6224,7 +8340,13 @@
 					<key>CodecID</key>
 					<integer>351359057</integer>
 					<key>ConfigData</key>
-					<data>AWccQAFnHUABZx4hAWcfAQF3HPABdx0AAXceAAF3H0ABhxwwAYcdMAGHHoEBhx8BAZcc8AGXHQABlx4AAZcfQAGnHBABpx0BAaceFwGnH5ABtxzwAbcdAAG3HgABtx9AAccc8AHHHQABxx4AAccfQAHXHCAB1x0BAdceoAHXH5A=</data>
+					<data>
+					AWccQAFnHUABZx4hAWcfAQF3HPABdx0AAXce
+					AAF3H0ABhxwwAYcdMAGHHoEBhx8BAZcc8AGX
+					HQABlx4AAZcfQAGnHBABpx0BAaceFwGnH5AB
+					txzwAbcdAAG3HgABtx9AAccc8AHHHQABxx4A
+					AccfQAHXHCAB1x0BAdceoAHXH5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6238,7 +8360,14 @@
 					<key>CodecID</key>
 					<integer>351359079</integer>
 					<key>ConfigData</key>
-					<data>AZcc8AGXHUABlx4hAZcfBAGnHPABpx2QAaceoQGnHwQBtxzwAbcdAQG3HgABtx9AAccc8AHHHQEBxx4AAccfQAHXHPAB1x0BAdceAAHXH0AB5xzwAecdAQHnHqcB5x+VAfcc8AH3HQEB9x4XAfcfkgIHHPACBx0RAgceRQIHHwQCJxzwAicdAQInHgACJx9AAjcc8AI3HQECNx4AAjcfQA==</data>
+					<data>
+					AZcc8AGXHUABlx4hAZcfBAGnHPABpx2QAace
+					oQGnHwQBtxzwAbcdAQG3HgABtx9AAccc8AHH
+					HQEBxx4AAccfQAHXHPAB1x0BAdceAAHXH0AB
+					5xzwAecdAQHnHqcB5x+VAfcc8AH3HQEB9x4X
+					AfcfkgIHHPACBx0RAgceRQIHHwQCJxzwAicd
+					AQInHgACJx9AAjcc8AI3HQECNx4AAjcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6252,7 +8381,14 @@
 					<key>CodecID</key>
 					<integer>351359081</integer>
 					<key>ConfigData</key>
-					<data>AZccEAGXHRABlx4gAZcfAAGnHCABpx0AAaceAAGnH0ABtxwwAbcdEAG3HoABtx8AAcccUAHHHQABxx4AAccfQAHXHGAB1x0AAdceAAHXH0AB5xxgAecdAAHnHgAB5x9AAfcccAH3HQAB9x4QAfcfkAIHHIACBx0AAgceAAIHH0ACJxyAAicdAAInHgACJx9AAjcckAI3HQACNx6gAjcfkA==</data>
+					<data>
+					AZccEAGXHRABlx4gAZcfAAGnHCABpx0AAace
+					AAGnH0ABtxwwAbcdEAG3HoABtx8AAcccUAHH
+					HQABxx4AAccfQAHXHGAB1x0AAdceAAHXH0AB
+					5xxgAecdAAHnHgAB5x9AAfcccAH3HQAB9x4Q
+					AfcfkAIHHIACBx0AAgceAAIHH0ACJxyAAicd
+					AAInHgACJx9AAjcckAI3HQACNx6gAjcfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6266,7 +8402,14 @@
 					<key>CodecID</key>
 					<integer>351359081</integer>
 					<key>ConfigData</key>
-					<data>AZccEAGXHRABlx4gAZcfAAGnHCABpx0wAacegQGnHwEBtxwwAbcdAAG3HgABtx9AAcccUAHHHQABxx4AAccfQAHXHGAB1x0AAdceAAHXH0AB5xxgAecdAAHnHgAB5x9AAfcccAH3HQAB9x4QAfcfkAIHHIACBx0AAgceAAIHH0ACJxyAAicdAAInHgACJx9AAjcckAI3HQECNx6gAjcfkA==</data>
+					<data>
+					AZccEAGXHRABlx4gAZcfAAGnHCABpx0wAace
+					gQGnHwEBtxwwAbcdAAG3HgABtx9AAcccUAHH
+					HQABxx4AAccfQAHXHGAB1x0AAdceAAHXH0AB
+					5xxgAecdAAHnHgAB5x9AAfcccAH3HQAB9x4Q
+					AfcfkAIHHIACBx0AAgceAAIHH0ACJxyAAicd
+					AAInHgACJx9AAjcckAI3HQECNx6gAjcfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6280,7 +8423,11 @@
 					<key>CodecID</key>
 					<integer>351359084</integer>
 					<key>ConfigData</key>
-					<data>AZccQAGXHRABlx4hAZcfAgG3HDABtx0QAbceowG3H5kCNxxQAjcdAQI3HqECNx+SAfccEAH3HQEB9x4TAfcfmQ==</data>
+					<data>
+					AZccQAGXHRABlx4hAZcfAgG3HDABtx0QAbce
+					owG3H5kCNxxQAjcdAQI3HqECNx+SAfccEAH3
+					HQEB9x4TAfcfmQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6294,7 +8441,11 @@
 					<key>CodecID</key>
 					<integer>351359086</integer>
 					<key>ConfigData</key>
-					<data>AZccQAGXHRABlx4hAZcfAAGnHDABpx0QAacegQGnHwABtxwgAbcdAAG3HqcBtx+QAfccEAH3HQAB9x4XAfcfkQ==</data>
+					<data>
+					AZccQAGXHRABlx4hAZcfAAGnHDABpx0QAace
+					gQGnHwABtxwgAbcdAAG3HqcBtx+QAfccEAH3
+					HQAB9x4XAfcfkQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6308,7 +8459,14 @@
 					<key>Comment</key>
 					<string>CX20590 Custom for Lenovo Yoga 13 by usr-sse2</string>
 					<key>ConfigData</key>
-					<data>AZccMAGXHUABlx4rAZcfDgH3HCAB9x0BAfceEAH3H5ACNxwQAjcdAQI3HqACNx+QAaccQAGnHRABpx6BAacfAQG3HPABtx0AAbceAAG3H0ABxxzwAccdAAHHHgABxx9AAdcc8AHXHQAB1x4AAdcfQAHnHPAB5x0AAeceAAHnH0ACBxzwAgcdAAIHHgACBx9AAicc8AInHQACJx4AAicfQA==</data>
+					<data>
+					AZccMAGXHUABlx4rAZcfDgH3HCAB9x0BAfce
+					EAH3H5ACNxwQAjcdAQI3HqACNx+QAaccQAGn
+					HRABpx6BAacfAQG3HPABtx0AAbceAAG3H0AB
+					xxzwAccdAAHHHgABxx9AAdcc8AHXHQAB1x4A
+					AdcfQAHnHPAB5x0AAeceAAHnH0ACBxzwAgcd
+					AAIHHgACBx9AAicc8AInHQACJx4AAicfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6322,7 +8480,14 @@
 					<key>Comment</key>
 					<string>CX20590 for Lenovo T420 by tluck (Additional ports for use with a Docking Station)</string>
 					<key>ConfigData</key>
-					<data>AFccAABXHQAAVx5WAFcfGABnHBAAZx0AAGceVgBnHxgAdxwgAHcdAAB3HlYAdx8YAZccMAGXHRABlx4hAZcfBAGnHEABpx2QAaceoQGnH2EBtxxQAbcdEAG3HoEBtx8BAcccYAHHHUABxx4hAccfYQH3HHAB9x0BAfceFwH3H5kCNxyAAjcdAQI3HqYCNx+ZAbcMAg==</data>
+					<data>
+					AFccAABXHQAAVx5WAFcfGABnHBAAZx0AAGce
+					VgBnHxgAdxwgAHcdAAB3HlYAdx8YAZccMAGX
+					HRABlx4hAZcfBAGnHEABpx2QAaceoQGnH2EB
+					txxQAbcdEAG3HoEBtx8BAcccYAHHHUABxx4h
+					AccfYQH3HHAB9x0BAfceFwH3H5kCNxyAAjcd
+					AQI3HqYCNx+ZAbcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6340,7 +8505,14 @@
 					<key>Comment</key>
 					<string>CX20590 for Lenovo T420 by tluck (Standard Laptop)</string>
 					<key>ConfigData</key>
-					<data>AFccAABXHQAAVx5WAFcfGABnHBAAZx0AAGceVgBnHxgAdxwgAHcdAAB3HlYAdx8YAZccMAGXHRABlx4hAZcfBAGnHEABpx2QAaceoQGnH2EBtxxQAbcdEAG3HoEBtx8BAcccYAHHHUABxx4hAccfYQH3HHAB9x0BAfceFwH3H5kCNxyAAjcdAQI3HqYCNx+ZAbcMAg==</data>
+					<data>
+					AFccAABXHQAAVx5WAFcfGABnHBAAZx0AAGce
+					VgBnHxgAdxwgAHcdAAB3HlYAdx8YAZccMAGX
+					HRABlx4hAZcfBAGnHEABpx2QAaceoQGnH2EB
+					txxQAbcdEAG3HoEBtx8BAcccYAHHHUABxx4h
+					AccfYQH3HHAB9x0BAfceFwH3H5kCNxyAAjcd
+					AQI3HqYCNx+ZAbcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6358,7 +8530,11 @@
 					<key>Comment</key>
 					<string>CX20641 - MacPeet - Dell OptiPlex 3010 - ManualMode</string>
 					<key>ConfigData</key>
-					<data>IcccECHHHUAhxx4BIccfASGnHCAhpx2QIacegSGnHwIhtxwwIbcdMCG3HoEhtx8BIZccQCGXHUAhlx4hIZcfAg==</data>
+					<data>
+					IcccECHHHUAhxx4BIccfASGnHCAhpx2QIace
+					gSGnHwIhtxwwIbcdMCG3HoEhtx8BIZccQCGX
+					HUAhlx4hIZcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6372,7 +8548,11 @@
 					<key>Comment</key>
 					<string>CX20641 - MacPeet - Dell OptiPlex 3010 - SwitchMode</string>
 					<key>ConfigData</key>
-					<data>IcccECHHHUAhxx4RIccfkCGnHCAhpx2QIacegSGnHwIhtxwwIbcdMCG3HoEhtx8BIZccQCGXHUAhlx4hIZcfAg==</data>
+					<data>
+					IcccECHHHUAhxx4RIccfkCGnHCAhpx2QIace
+					gSGnHwIhtxwwIbcdMCG3HoEhtx8BIZccQCGX
+					HUAhlx4hIZcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6386,7 +8566,11 @@
 					<key>Comment</key>
 					<string>CX20642 - MacPeet - Fujitsu ESPRIMO E910 E90+ Desktop - ManualMode</string>
 					<key>ConfigData</key>
-					<data>IcccECHHHUAhxx4BIccfASGnHCAhpx0QIacegSGnHwIhlxxAIZcdECGXHiEhlx8CIdccUCHXHTAh1x6BIdcfAQ==</data>
+					<data>
+					IcccECHHHUAhxx4BIccfASGnHCAhpx0QIace
+					gSGnHwIhlxxAIZcdECGXHiEhlx8CIdccUCHX
+					HTAh1x6BIdcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6400,7 +8584,11 @@
 					<key>Comment</key>
 					<string>CX20642 - MacPeet - Fujitsu ESPRIMO E910 E90+ Desktop - SwitchMode</string>
 					<key>ConfigData</key>
-					<data>IcccECHHHUAhxx4RIccfkCGnHCAhpx0QIaceoSGnH5IhlxxAIZcdECGXHiEhlx8CIdccUCHXHTAh1x6BIdcfAQ==</data>
+					<data>
+					IcccECHHHUAhxx4RIccfkCGnHCAhpx0QIace
+					oSGnH5IhlxxAIZcdECGXHiEhlx8CIdccUCHX
+					HTAh1x6BIdcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6414,7 +8602,11 @@
 					<key>Comment</key>
 					<string>Custom for Dell Vostro 3x60 by vusun123</string>
 					<key>ConfigData</key>
-					<data>AfccEAH3HQAB9x4XAfcfkQGnHDABpx0QAacegQGnHwkBlxxAAZcdEAGXHiEBlx8AAjccIAI3HQECNx6nAjcfkAG3DAIB1wwC</data>
+					<data>
+					AfccEAH3HQAB9x4XAfcfkQGnHDABpx0QAace
+					gQGnHwkBlxxAAZcdEAGXHiEBlx8AAjccIAI3
+					HQECNx6nAjcfkAG3DAIB1wwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6428,7 +8620,11 @@
 					<key>CodecID</key>
 					<integer>351359218</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4WAXcfkQGnHCABpx0AAacepgGnH5ABlxwwAZcdEAGXHoEBlx8CAWccQAFnHRABZx4hAWcfAg==</data>
+					<data>
+					AXccEAF3HQABdx4WAXcfkQGnHCABpx0AAace
+					pgGnH5ABlxwwAZcdEAGXHoEBlx8CAWccQAFn
+					HRABZx4hAWcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6442,7 +8638,11 @@
 					<key>CodecID</key>
 					<integer>351359220</integer>
 					<key>ConfigData</key>
-					<data>AWccEAFnHRABZx4hAWcfAgF3HCABdx0AAXceFwF3H5EBlxwwAZcdEAGXHoEBlx8CAaccQAGnHQABpx6mAacfkA==</data>
+					<data>
+					AWccEAFnHRABZx4hAWcfAgF3HCABdx0AAXce
+					FwF3H5EBlxwwAZcdEAGXHoEBlx8CAaccQAGn
+					HQABpx6mAacfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6456,7 +8656,11 @@
 					<key>CodecID</key>
 					<integer>351359220</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQEBdx4XAXcfkQGnHCABpx0BAaceoAGnH5UBlxwwAZcdEAGXHosBlx8EAdccQAHXHRAB1x4rAdcfBA==</data>
+					<data>
+					AXccEAF3HQEBdx4XAXcfkQGnHCABpx0BAace
+					oAGnH5UBlxwwAZcdEAGXHosBlx8EAdccQAHX
+					HRAB1x4rAdcfBA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6470,7 +8674,11 @@
 					<key>CodecID</key>
 					<integer>351359247</integer>
 					<key>ConfigData</key>
-					<data>AWccEAFnHUABZx4hAWcfAQF3HCABdx0AAXceFwF3H5ABhxwwAYcdkAGHHoEBhx8BAaccQAGnHQABpx6gAacfkA==</data>
+					<data>
+					AWccEAFnHUABZx4hAWcfAQF3HCABdx0AAXce
+					FwF3H5ABhxwwAYcdkAGHHoEBhx8BAaccQAGn
+					HQABpx6gAacfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6482,7 +8690,11 @@
 					<key>CodecID</key>
 					<integer>351359247</integer>
 					<key>ConfigData</key>
-					<data>AZcHJAGnByQBZxxAAWcdEAFnHiEBZx8EAXccEAF3HQEBdx4XAXcfkAGXHDABlx0QAZcegQGXHwQBpxwgAacdAQGnHqABpx+Q</data>
+					<data>
+					AZcHJAGnByQBZxxAAWcdEAFnHiEBZx8EAXcc
+					EAF3HQEBdx4XAXcfkAGXHDABlx0QAZcegQGX
+					HwQBpxwgAacdAQGnHqABpx+Q
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6498,7 +8710,11 @@
 					<key>CodecID</key>
 					<integer>351359247</integer>
 					<key>ConfigData</key>
-					<data>AWccQAFnHRABZx4hAWcfBAF3HBABdx0BAXceFwF3H5ABlxwwAZcdEAGXHoEBlx8EAZcHJAGnHCABpx0BAaceoAGnH5ABpwck</data>
+					<data>
+					AWccQAFnHRABZx4hAWcfBAF3HBABdx0BAXce
+					FwF3H5ABlxwwAZcdEAGXHoEBlx8EAZcHJAGn
+					HCABpx0BAaceoAGnH5ABpwck
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6516,7 +8732,11 @@
 					<key>CodecID</key>
 					<integer>351359249</integer>
 					<key>ConfigData</key>
-					<data>AWccEAFnHUABZx4hAWcfAgF3HCABdx0AAXceFwF3H5ABlxwwAZcdkAGXHoEBlx8CAaccQAGnHQABpx6gAacfkA==</data>
+					<data>
+					AWccEAFnHUABZx4hAWcfAgF3HCABdx0AAXce
+					FwF3H5ABlxwwAZcdkAGXHoEBlx8CAaccQAGn
+					HQABpx6gAacfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6530,7 +8750,11 @@
 					<key>CodecID</key>
 					<integer>351359249</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQEBdx4XAXcfkAFnHBMBZx0QAWceIQFnHwMBlxwwAZcdEAGXHoEBlx8DAaccQAGnHQEBpx6gAacfkA==</data>
+					<data>
+					AXccEAF3HQEBdx4XAXcfkAFnHBMBZx0QAWce
+					IQFnHwMBlxwwAZcdEAGXHoEBlx8DAaccQAGn
+					HQEBpx6gAacfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6544,7 +8768,11 @@
 					<key>CodecID</key>
 					<integer>351359249</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAacepgGnH5ABlxwwAZcdEAGXHoEBlx8AAWccQAFnHRABZx4hAWcfAA==</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
+					pgGnH5ABlxwwAZcdEAGXHoEBlx8AAWccQAFn
+					HRABZx4hAWcfAA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6558,7 +8786,11 @@
 					<key>CodecID</key>
 					<integer>351359249</integer>
 					<key>ConfigData</key>
-					<data>AXccIAF3HQEBdx4XAXcfkAGXHDABlx0QAZcegQGXHwMBpxxAAacdAQGnHqABpx+QAdccEAHXHRAB1x4hAdcfAw==</data>
+					<data>
+					AXccIAF3HQEBdx4XAXcfkAGXHDABlx0QAZce
+					gQGXHwMBpxxAAacdAQGnHqABpx+QAdccEAHX
+					HRAB1x4hAdcfAw==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6572,7 +8804,11 @@
 					<key>CodecID</key>
 					<integer>351359251</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAacepgGnH5UBhxwwAYcdkAGHHosBhx8CAWccQAFnHUABZx4rAWcfAg==</data>
+					<data>
+					AXccEAF3HQABdx4XAXcfkAGnHCABpx0AAace
+					pgGnH5UBhxwwAYcdkAGHHosBhx8CAWccQAFn
+					HUABZx4rAWcfAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6586,7 +8822,11 @@
 					<key>CodecID</key>
 					<integer>351359252</integer>
 					<key>ConfigData</key>
-					<data>AWccEAFnHUABZx4hAWcfAQF3HCABdx0AAXceEwF3H5ABhxwwAYcdkAGHHqEBhx8CAaccQAGnHQABpx6mAacfkA==</data>
+					<data>
+					AWccEAFnHUABZx4hAWcfAQF3HCABdx0AAXce
+					EwF3H5ABhxwwAYcdkAGHHqEBhx8CAaccQAGn
+					HQABpx6mAacfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6600,7 +8840,11 @@
 					<key>CodecID</key>
 					<integer>351359252</integer>
 					<key>ConfigData</key>
-					<data>AXccEAF3HQEBdx4XAXcfkAGnHCABpx0BAaceoAGnH5ABlxwwAZcdEAGXHosBlx8CAWccQAFnHRABZx4rAWcfAgGHHPABhx0AAYceAAGHH0A=</data>
+					<data>
+					AXccEAF3HQEBdx4XAXcfkAGnHCABpx0BAace
+					oAGnH5ABlxwwAZcdEAGXHosBlx8CAWccQAFn
+					HRABZx4rAWcfAgGHHPABhx0AAYceAAGHH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6614,7 +8858,11 @@
 					<key>CodecID</key>
 					<integer>351359253</integer>
 					<key>ConfigData</key>
-					<data>AWccEAFnHQABZx4hAWcfAQF3HCABdx0AAXceEwF3H5ABhxwwAYcdAAGHHoEBhx8CAaccUAGnHQABpx6gAacfkA==</data>
+					<data>
+					AWccEAFnHQABZx4hAWcfAQF3HCABdx0AAXce
+					EwF3H5ABhxwwAYcdAAGHHoEBhx8CAaccUAGn
+					HQABpx6gAacfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6642,7 +8890,11 @@
 					<key>CodecID</key>
 					<integer>287143633</integer>
 					<key>ConfigData</key>
-					<data>ANccAADXHQAA1x4XANcfmQEXHCABFx0AARceoAEXH5kAtxwwALcdQAC3HiEAtx8BAMccQADHHRAAxx6AAMcfAQ==</data>
+					<data>
+					ANccAADXHQAA1x4XANcfmQEXHCABFx0AARce
+					oAEXH5kAtxwwALcdQAC3HiEAtx8BAMccQADH
+					HRAAxx6AAMcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6670,7 +8922,11 @@
 					<key>CodecID</key>
 					<integer>287143573</integer>
 					<key>ConfigData</key>
-					<data>AKccEACnHRAApx4hAKcfAgCnDAIAtxwgALcdEAC3HqEAtx8CALcMAgDXHDAA1x0BANceFwDXH5AA1wwCAOccQADnHQEA5x6gAOcfkA==</data>
+					<data>
+					AKccEACnHRAApx4hAKcfAgCnDAIAtxwgALcd
+					EAC3HqEAtx8CALcMAgDXHDAA1x0BANceFwDX
+					H5AA1wwCAOccQADnHQEA5x6gAOcfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6684,7 +8940,11 @@
 					<key>CodecID</key>
 					<integer>287143667</integer>
 					<key>ConfigData</key>
-					<data>AKccEACnHUAApx4hAKcfAgC3HCAAtx1AALceEwC3H5AAxxwwAMcdkADHHoEAxx8CAOccQADnHZAA5x6gAOcfkA==</data>
+					<data>
+					AKccEACnHUAApx4hAKcfAgC3HCAAtx1AALce
+					EwC3H5AAxxwwAMcdkADHHoEAxx8CAOccQADn
+					HZAA5x6gAOcfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6698,7 +8958,16 @@
 					<key>CodecID</key>
 					<integer>287143602</integer>
 					<key>ConfigData</key>
-					<data>AKccEACnHRAApx4hAKcfAAC3HCAAtx0QALcegQC3HwIAxxwwAMcdAADHHvAAxx9AANccQADXHQAA1x4XANcfkADnHFAA5x0QAOceoQDnHyABRxxgAUcdAAFHHvABRx9AAYcccAGHHQABhx6gAYcfkAGXHIABlx0AAZce8AGXH0AB5xyQAecdEAHnHkYB5x8BAfccoAH3HQAB9x7wAfcfQAIHHLACBx0AAgce8AIHH0ACdxzAAncdAAJ3HvACdx9A</data>
+					<data>
+					AKccEACnHRAApx4hAKcfAAC3HCAAtx0QALce
+					gQC3HwIAxxwwAMcdAADHHvAAxx9AANccQADX
+					HQAA1x4XANcfkADnHFAA5x0QAOceoQDnHyAB
+					RxxgAUcdAAFHHvABRx9AAYcccAGHHQABhx6g
+					AYcfkAGXHIABlx0AAZce8AGXH0AB5xyQAecd
+					EAHnHkYB5x8BAfccoAH3HQAB9x7wAfcfQAIH
+					HLACBx0AAgce8AIHH0ACdxzAAncdAAJ3HvAC
+					dx9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6712,7 +8981,11 @@
 					<key>CodecID</key>
 					<integer>287143541</integer>
 					<key>ConfigData</key>
-					<data>AKccEACnHRAApx4hAKcfAwDXHCAA1x0BANceFwDXH5AA5xwwAOcdEADnHoEA5x8DAPccQAD3HRAA9x4BAPcfAwE3HFABNx0BATceoAE3H5A=</data>
+					<data>
+					AKccEACnHRAApx4hAKcfAwDXHCAA1x0BANce
+					FwDXH5AA5xwwAOcdEADnHoEA5x8DAPccQAD3
+					HRAA9x4BAPcfAwE3HFABNx0BATceoAE3H5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6726,7 +8999,11 @@
 					<key>CodecID</key>
 					<integer>287143541</integer>
 					<key>ConfigData</key>
-					<data>AKccEACnHRAApx4hAKcfBADHHCAAxx0QAMcegQDHHwQA5xwwAOcdAQDnHhcA5x+QATccQAE3HQEBNx6gATcfkA==</data>
+					<data>
+					AKccEACnHRAApx4hAKcfBADHHCAAxx0QAMce
+					gQDHHwQA5xwwAOcdAQDnHhcA5x+QATccQAE3
+					HQEBNx6gATcfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6740,7 +9017,11 @@
 					<key>CodecID</key>
 					<integer>287143637</integer>
 					<key>ConfigData</key>
-					<data>AKccIACnHRAApx6BAKcfAgC3HDAAtx0QALceIQC3HwIA1xxAANcdAADXHhcA1x+QARccUAEXHQABFx6gARcfkA==</data>
+					<data>
+					AKccIACnHRAApx6BAKcfAgC3HDAAtx0QALce
+					IQC3HwIA1xxAANcdAADXHhcA1x+QARccUAEX
+					HQABFx6gARcfkA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6754,7 +9035,15 @@
 					<key>CodecID</key>
 					<integer>287143637</integer>
 					<key>ConfigData</key>
-					<data>AKccIACnHRAApx6BAKcfBACnDAIAtxwwALcdEAC3HiEAtx8EALcMAgDHHPAAxx0AAMceAADHH0AA1xxAANcdAQDXHhcA1x+QANcMAgDnHPAA5x0AAOceAADnH0AA9xzwAPcdAAD3HgAA9x9AAQcc8AEHHQABBx4AAQcfQAEXHFABFx0BARceoAEXH5AB9xzwAfcdAAH3HgAB9x9AAgcc8AIHHQACBx4AAgcfQA==</data>
+					<data>
+					AKccIACnHRAApx6BAKcfBACnDAIAtxwwALcd
+					EAC3HiEAtx8EALcMAgDHHPAAxx0AAMceAADH
+					H0AA1xxAANcdAQDXHhcA1x+QANcMAgDnHPAA
+					5x0AAOceAADnH0AA9xzwAPcdAAD3HgAA9x9A
+					AQcc8AEHHQABBx4AAQcfQAEXHFABFx0BARce
+					oAEXH5AB9xzwAfcdAAH3HgAB9x9AAgcc8AIH
+					HQACBx4AAgcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6768,7 +9057,14 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>AKccIACnHRAApx6hAKcfAQC3HBAAtx0QALceIQC3HwEA1xwwANcdAADXHhcA1x+QAOcc8ADnHQAA5x4AAOcfQAD3HEAA9x0AAPceAAD3H0ABBxxQAQcdAAEHHgABBx9AARccYAEXHQABFx6jARcf0AH3HHAB9x0AAfceAAH3H0ACBxyAAgcdAAIHHgACBx9A</data>
+					<data>
+					AKccIACnHRAApx6hAKcfAQC3HBAAtx0QALce
+					IQC3HwEA1xwwANcdAADXHhcA1x+QAOcc8ADn
+					HQAA5x4AAOcfQAD3HEAA9x0AAPceAAD3H0AB
+					BxxQAQcdAAEHHgABBx9AARccYAEXHQABFx6j
+					ARcf0AH3HHAB9x0AAfceAAH3H0ACBxyAAgcd
+					AAIHHgACBx9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6782,7 +9078,15 @@
 					<key>CodecID</key>
 					<integer>283902515</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHRABJx6BAScfBAFHHCABRx0BAUceFwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGHHPABhx0AAYceAAGHH0ABlxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4AAacfQAG3HDABtx0BAbceoAG3H5AB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHEACFx0QAhceIQIXHwMCFwwC</data>
+					<data>
+					ASccEAEnHRABJx6BAScfBAFHHCABRx0BAUce
+					FwFHH5ABRwwCAXcc8AF3HQABdx4AAXcfQAGH
+					HPABhx0AAYceAAGHH0ABlxzwAZcdAAGXHgAB
+					lx9AAacc8AGnHQABpx4AAacfQAG3HDABtx0B
+					AbceoAG3H5AB1xzwAdcdAAHXHgAB1x9AAecc
+					8AHnHQAB5x4AAecfQAIXHEACFx0QAhceIQIX
+					HwMCFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6810,7 +9114,14 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>AKccIACnHRAApx6BAKcfAQC3HFAAtx0QALceIQC3HwEA1xwwANcdAQDXHhAA1x+QAOcc8ADnHQAA5x4AAOcfQAD3HPAA9x0AAPceAAD3H0ABBxzwAQcdAAEHHgABBx9AARccEAEXHQEBFx6gARcfkAH3HPAB9x0AAfceAAH3H0ACBxzwAgcdAAIHHgACBx9AAMcc8ADHHQAAxx4AAMcfQA==</data>
+					<data>
+					AKccIACnHRAApx6BAKcfAQC3HFAAtx0QALce
+					IQC3HwEA1xwwANcdAQDXHhAA1x+QAOcc8ADn
+					HQAA5x4AAOcfQAD3HPAA9x0AAPceAAD3H0AB
+					BxzwAQcdAAEHHgABBx9AARccEAEXHQEBFx6g
+					ARcfkAH3HPAB9x0AAfceAAH3H0ACBxzwAgcd
+					AAIHHgACBx9AAMcc8ADHHQAAxx4AAMcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6824,7 +9135,14 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>AMccIADHHRAAxx6BAMcfAQC3HFAAtx0QALceIQC3HwEA9xwwAPcdAQD3HhAA9x+QAOcc8ADnHQAA5x4AAOcfQADXHPAA1x0AANceAADXH0ABBxzwAQcdAAEHHgABBx9AARccEAEXHQEBFx6gARcfkAH3HPAB9x0AAfceAAH3H0ACBxzwAgcdAAIHHgACBx9AAKcc8ACnHQAApx4AAKcfQA==</data>
+					<data>
+					AMccIADHHRAAxx6BAMcfAQC3HFAAtx0QALce
+					IQC3HwEA9xwwAPcdAQD3HhAA9x+QAOcc8ADn
+					HQAA5x4AAOcfQADXHPAA1x0AANceAADXH0AB
+					BxzwAQcdAAEHHgABBx9AARccEAEXHQEBFx6g
+					ARcfkAH3HPAB9x0AAfceAAH3H0ACBxzwAgcd
+					AAIHHgACBx9AAKcc8ACnHQAApx4AAKcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6838,7 +9156,11 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>ARccAAEXHQEBFx6jARcfmQDHHBAAxx0QAMcegQDHHwEA1xwgANcdAQDXHhMA1x+ZALccMAC3HRAAtx4hALcfAQFHDAI=</data>
+					<data>
+					ARccAAEXHQEBFx6jARcfmQDHHBAAxx0QAMce
+					gQDHHwEA1xwgANcdAQDXHhMA1x+ZALccMAC3
+					HRAAtx4hALcfAQFHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6852,7 +9174,14 @@
 					<key>CodecID</key>
 					<integer>287143432</integer>
 					<key>ConfigData</key>
-					<data>AKccEACnHRAApx4hAKcfAQC3HCAAtx0QALcegQC3HwEAxxwwAMcdEADHHqAAxx+QANccQADXHQAA1x4RANcfkADnHFAA5x0AAOce8ADnH0ABRxxgAUcdAAFHHvABRx9AAYcccAGHHQABhx7wAYcfQAHnHIAB5x0AAece8AHnH0AB9xyQAfcdAAH3HvAB9x9AAgccoAIHHQACBx7wAgcfQA==</data>
+					<data>
+					AKccEACnHRAApx4hAKcfAQC3HCAAtx0QALce
+					gQC3HwEAxxwwAMcdEADHHqAAxx+QANccQADX
+					HQAA1x4RANcfkADnHFAA5x0AAOce8ADnH0AB
+					RxxgAUcdAAFHHvABRx9AAYcccAGHHQABhx7w
+					AYcfQAHnHIAB5x0AAece8AHnH0AB9xyQAfcd
+					AAH3HvAB9x9AAgccoAIHHQACBx7wAgcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6866,7 +9195,11 @@
 					<key>CodecID</key>
 					<integer>287143427</integer>
 					<key>ConfigData</key>
-					<data>ALccEAC3HRAAtx6gALcfkADXHCAA1x0AANceFwDXH5AA9xwwAPcdQAD3HiEA9x8BAYccQAGHHZABhx6BAYcfAQ==</data>
+					<data>
+					ALccEAC3HRAAtx6gALcfkADXHCAA1x0AANce
+					FwDXH5AA9xwwAPcdQAD3HiEA9x8BAYccQAGH
+					HZABhx6BAYcfAQ==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6880,7 +9213,10 @@
 					<key>CodecID</key>
 					<integer>287143427</integer>
 					<key>ConfigData</key>
-					<data>ALccAAC3HQAAtx6nALcfmQDXHBAA1x0AANceFwDXH5kA9xwgAPcdQAD3HiEA9x8B</data>
+					<data>
+					ALccAAC3HQAAtx6nALcfmQDXHBAA1x0AANce
+					FwDXH5kA9xwgAPcdQAD3HiEA9x8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6894,7 +9230,13 @@
 					<key>CodecID</key>
 					<integer>287143655</integer>
 					<key>ConfigData</key>
-					<data>ALccEAC3HRAAtx4hALcfAACnHCAApx0QAKcegQCnHwABFxwwARcdkAEXHqABFx+QANccQADXHQAA1x4XANcfkADnHFAA5x0QAOceAQDnHyAA9xxgAPcdEAD3HqEA9x8gAQcc8AEHHQABBx4AAQcfQA==</data>
+					<data>
+					ALccEAC3HRAAtx4hALcfAACnHCAApx0QAKce
+					gQCnHwABFxwwARcdkAEXHqABFx+QANccQADX
+					HQAA1x4XANcfkADnHFAA5x0QAOceAQDnHyAA
+					9xxgAPcdEAD3HqEA9x8gAQcc8AEHHQABBx4A
+					AQcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6908,7 +9250,11 @@
 					<key>CodecID</key>
 					<integer>287143655</integer>
 					<key>ConfigData</key>
-					<data>AKccIACnHRAApx6BAKcfAAC3HBAAtx0QALceIQC3HwAA1xxAANcdAADXHhcA1x+QARccMAEXHQABFx6gARcf0A==</data>
+					<data>
+					AKccIACnHRAApx6BAKcfAAC3HBAAtx0QALce
+					IQC3HwAA1xxAANcdAADXHhcA1x+QARccMAEX
+					HQABFx6gARcf0A==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6922,7 +9268,14 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALceIQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEXHQABFx6gARcfmQDXHEAA1x0BANceFwDXH5kA5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4AAQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcdAAIHHgACBx9J</data>
+					<data>
+					AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALce
+					IQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEX
+					HQABFx6gARcfmQDXHEAA1x0BANceFwDXH5kA
+					5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4A
+					AQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcd
+					AAIHHgACBx9J
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6936,7 +9289,14 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALceIQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEXHQABFx6gARcfmQD3HEAA9x0BAPceFwD3H5kA5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4AAQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcdAAIHHgACBx9J</data>
+					<data>
+					AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALce
+					IQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEX
+					HQABFx6gARcfmQD3HEAA9x0BAPceFwD3H5kA
+					5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4A
+					AQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcd
+					AAIHHgACBx9J
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6950,7 +9310,11 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>ALccEAC3HRAAtx4hALcfAAC3DAIAxxwgAMcdEADHHoEAxx8AARccMAEXHQABFx6jARcfmQDXHEAA1x0AANceEADXH5AA1wwC</data>
+					<data>
+					ALccEAC3HRAAtx4hALcfAAC3DAIAxxwgAMcd
+					EADHHoEAxx8AARccMAEXHQABFx6jARcfmQDX
+					HEAA1x0AANceEADXH5AA1wwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6964,7 +9328,14 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>ALccIAC3HRAAtx4hALcfAwD3HDIA9x0BAPceFwD3H5ABFxwQARcdAQEXHqYBFx+XANcc8ADXHQAA1x4AANcfQAEHHPABBx0AAQceAAEHH0AApxzwAKcdAACnHgAApx9AAMcc8ADHHQAAxx4AAMcfQADnHPAA5x0AAOceAADnH0AB9xzwAfcdAAH3HgAB9x9AAgcc8AIHHQACBx4AAgcfQA==</data>
+					<data>
+					ALccIAC3HRAAtx4hALcfAwD3HDIA9x0BAPce
+					FwD3H5ABFxwQARcdAQEXHqYBFx+XANcc8ADX
+					HQAA1x4AANcfQAEHHPABBx0AAQceAAEHH0AA
+					pxzwAKcdAACnHgAApx9AAMcc8ADHHQAAxx4A
+					AMcfQADnHPAA5x0AAOceAADnH0AB9xzwAfcd
+					AAH3HgAB9x9AAgcc8AIHHQACBx4AAgcfQA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6978,7 +9349,14 @@
 					<key>CodecID</key>
 					<integer>287143648</integer>
 					<key>ConfigData</key>
-					<data>AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALceIQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEXHQABFx6gARcfmQD3HEAA9x0BAPceFwD3H5kA5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4AAQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcdAAIHHgACBx9J</data>
+					<data>
+					AKccAACnHRAApx6BAKcfAQC3HBAAtx0QALce
+					IQC3HwMAxxwgAMcdAADHHgAAxx9JARccMAEX
+					HQABFx6gARcfmQD3HEAA9x0BAPceFwD3H5kA
+					5xxQAOcdEADnHgEA5x8jAQccYAEHHQABBx4A
+					AQcfSQH3HHAB9x0AAfceAAH3H0kCBxyAAgcd
+					AAIHHgACBx9J
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -6992,7 +9370,13 @@
 					<key>CodecID</key>
 					<integer>287143647</integer>
 					<key>ConfigData</key>
-					<data>AKccIACnHRAApx6BAKcfAACnDAIAtxwQALcdEAC3HiEAtx8AALcMAgDXHEAA1x0BANceFwDXH5AA1wwCAOccUADnHRAA5x4BAOcfIADnDAIA9xxgAPcdEAD3HoEA9x8gAQcc8AEHHQABBx4AAQcfQAEXHDABFx0BARceoAEXH5A=</data>
+					<data>
+					AKccIACnHRAApx6BAKcfAACnDAIAtxwQALcd
+					EAC3HiEAtx8AALcMAgDXHEAA1x0BANceFwDX
+					H5AA1wwCAOccUADnHRAA5x4BAOcfIADnDAIA
+					9xxgAPcdEAD3HoEA9x8gAQcc8AEHHQABBx4A
+					AQcfQAEXHDABFx0BARceoAEXH5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7006,7 +9390,12 @@
 					<key>CodecID</key>
 					<integer>287143653</integer>
 					<key>ConfigData</key>
-					<data>AKccEACnHZAApx6BAKcfAgC3HCAAtx1AALceIQC3HwIAxxwwAMcdAADHHvAAxx9AANccQADXHQAA1x4TANcf0AD3HFAA9x0AAPce8AD3H0ABFxxgARcdAAEXHqABFx+QANcMAg==</data>
+					<data>
+					AKccEACnHZAApx6BAKcfAgC3HCAAtx1AALce
+					IQC3HwIAxxwwAMcdAADHHvAAxx9AANccQADX
+					HQAA1x4TANcf0AD3HFAA9x0AAPce8AD3H0AB
+					FxxgARcdAAEXHqABFx+QANcMAg==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7020,7 +9409,14 @@
 					<key>CodecID</key>
 					<integer>287143429</integer>
 					<key>ConfigData</key>
-					<data>AKccIACnHRAApx6hAKcfAQC3HBAAtx0QALceIQC3HwEA1xwwANcdAADXHhcA1x+QAOcc8ADnHQAA5x4AAOcfQAD3HEAA9x0AAPceAAD3H0ABBxxQAQcdAAEHHgABBx9AARccYAEXHQABFx6jARcf0AH3HHAB9x0AAfceAAH3H0ACBxyAAgcdAAIHHgACBx9A</data>
+					<data>
+					AKccIACnHRAApx6hAKcfAQC3HBAAtx0QALce
+					IQC3HwEA1xwwANcdAADXHhcA1x+QAOcc8ADn
+					HQAA5x4AAOcfQAD3HEAA9x0AAPceAAD3H0AB
+					BxxQAQcdAAEHHgABBx9AARccYAEXHQABFx6j
+					ARcf0AH3HHAB9x0AAfceAAH3H0ACBxyAAgcd
+					AAIHHgACBx9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7034,7 +9430,13 @@
 					<key>CodecID</key>
 					<integer>2206496400</integer>
 					<key>ConfigData</key>
-					<data>AIcc8ACHHQAAhx4AAIcfQACXHPAAlx0AAJceAACXH0AA1xwQANcdEADXHiEA1x8CAOccIADnHQEA5x4QAOcfkAD3HDAA9x0BAPceoAD3H5ABBxxAAQcdEAEHHoEBBx8CARcc8AEXHQABFx4AARcfQAEnHPABJx0AASceAAEnH0A=</data>
+					<data>
+					AIcc8ACHHQAAhx4AAIcfQACXHPAAlx0AAJce
+					AACXH0AA1xwQANcdEADXHiEA1x8CAOccIADn
+					HQEA5x4QAOcfkAD3HDAA9x0BAPceoAD3H5AB
+					BxxAAQcdEAEHHoEBBx8CARcc8AEXHQABFx4A
+					ARcfQAEnHPABJx0AASceAAEnH0A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7048,7 +9450,11 @@
 					<key>CodecID</key>
 					<integer>2206496354</integer>
 					<key>ConfigData</key>
-					<data>APccEAD3HQEA9x4XAPcfkACnHCAApx1AAKceIQCnHwQBRxw+AUcdkAFHHqABRx+QARccQAEXHREBFx5WARcfGA==</data>
+					<data>
+					APccEAD3HQEA9x4XAPcfkACnHCAApx1AAKce
+					IQCnHwQBRxw+AUcdkAFHHqABRx+QARccQAEX
+					HREBFx5WARcfGA==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7062,7 +9468,11 @@
 					<key>CodecID</key>
 					<integer>285624160</integer>
 					<key>ConfigData</key>
-					<data>AkccEAJHHQACRx4AAkcfAQKHHCAChx1AAoceIQKHHwICtxwwArcdkAK3HoECtx8BAwccQAMHHQADBx6gAwcfkAJHDAI=</data>
+					<data>
+					AkccEAJHHQACRx4AAkcfAQKHHCAChx1AAoce
+					IQKHHwICtxwwArcdkAK3HoECtx8BAwccQAMH
+					HQADBx6gAwcfkAJHDAI=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7076,7 +9486,12 @@
 					<key>CodecID</key>
 					<integer>285639750</integer>
 					<key>ConfigData</key>
-					<data>AkccEAJHHQACRx4TAkcfkAJXHCACVx1AAlceIQJXHwEClxxAApcdAAKXHqAClx+QArccYAK3HZACtx6BArcfAgLXHHAC1x0QAtceRALXHwACRwwCAlcMAw==</data>
+					<data>
+					AkccEAJHHQACRx4TAkcfkAJXHCACVx1AAlce
+					IQJXHwEClxxAApcdAAKXHqAClx+QArccYAK3
+					HZACtx6BArcfAgLXHHAC1x0QAtceRALXHwAC
+					RwwCAlcMAw==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7090,7 +9505,12 @@
 					<key>CodecID</key>
 					<integer>285639750</integer>
 					<key>ConfigData</key>
-					<data>AkccEAJHHQACRx4TAkcfkAJXHCACVx1AAlceIQJXHwEClxxAApcdAAKXHqAClx+QArccYAK3HZACtx6BArcfAgLXHHAC1x0QAtceRALXHwACRwwCAlcMAw==</data>
+					<data>
+					AkccEAJHHQACRx4TAkcfkAJXHCACVx1AAlce
+					IQJXHwEClxxAApcdAAKXHqAClx+QArccYAK3
+					HZACtx6BArcfAgLXHHAC1x0QAtceRALXHwAC
+					RwwCAlcMAw==
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7104,7 +9524,11 @@
 					<key>CodecID</key>
 					<integer>285639750</integer>
 					<key>ConfigData</key>
-					<data>AkccQAJHHQACRx4XAkcfkAJHDAICVxxQAlcdEAJXHiECVx8CAlcMAgMHHBADBx0AAwceoAMHH5A=</data>
+					<data>
+					AkccQAJHHQACRx4XAkcfkAJHDAICVxxQAlcd
+					EAJXHiECVx8CAlcMAgMHHBADBx0AAwceoAMH
+					H5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7118,7 +9542,12 @@
 					<key>CodecID</key>
 					<integer>285606977</integer>
 					<key>ConfigData</key>
-					<data>IkccECJHHUAiRx4BIkcfASKHHCAihx1AIoceISKHHwEilxwwIpcdkCKXHqEilx8CIqccQCKnHTAipx6BIqcfASK3HFAitx2QIrcegSK3HwEi5xxgIucdECLnHkUi5x8A</data>
+					<data>
+					IkccECJHHUAiRx4BIkcfASKHHCAihx1AIoce
+					ISKHHwEilxwwIpcdkCKXHqEilx8CIqccQCKn
+					HTAipx6BIqcfASK3HFAitx2QIrcegSK3HwEi
+					5xxgIucdECLnHkUi5x8A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7132,7 +9561,14 @@
 					<key>CodecID</key>
 					<integer>285606977</integer>
 					<key>ConfigData</key>
-					<data>IkccECJHHUAiRx4RIkcfASJXHCAiVx0QIlceASJXHwEiZxwwImcdYCJnHgEiZx8BInccQCJ3HSAidx4BIncfASKHHFAihx1AIoceISKHHwEilxxgIpcdkCKXHqEilx8CIqcccCKnHTAipx6BIqcfASK3HIAitx2QIrcegSK3HwEi5xygIucdECLnHkUi5x8A</data>
+					<data>
+					IkccECJHHUAiRx4RIkcfASJXHCAiVx0QIlce
+					ASJXHwEiZxwwImcdYCJnHgEiZx8BInccQCJ3
+					HSAidx4BIncfASKHHFAihx1AIoceISKHHwEi
+					lxxgIpcdkCKXHqEilx8CIqcccCKnHTAipx6B
+					IqcfASK3HIAitx2QIrcegSK3HwEi5xygIucd
+					ECLnHkUi5x8A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7146,7 +9582,16 @@
 					<key>CodecID</key>
 					<integer>285606977</integer>
 					<key>ConfigData</key>
-					<data>Ihcc8CIXHQAiFx4AIhcfQCJHHBAiRx1AIkceESJHHwEiRwwCIlcc8CJXHQAiVx4AIlcfQCJnHPAiZx0AImceACJnH0AidxzwIncdACJ3HgAidx9AIoccICKHHUAihx4hIocfASKXHEAilx2QIpceoCKXH5AilwchIqccgCKnHTAipx6BIqcfASK3HPAitx0AIrceACK3H0AixxzwIscdACLHHgAixx9AItcc8CLXHQAi1x4AItcfQCLnHJAi5x1hIuceSyLnHwEi9xzwIvcdACL3HgAi9x9A</data>
+					<data>
+					Ihcc8CIXHQAiFx4AIhcfQCJHHBAiRx1AIkce
+					ESJHHwEiRwwCIlcc8CJXHQAiVx4AIlcfQCJn
+					HPAiZx0AImceACJnH0AidxzwIncdACJ3HgAi
+					dx9AIoccICKHHUAihx4hIocfASKXHEAilx2Q
+					IpceoCKXH5AilwchIqccgCKnHTAipx6BIqcf
+					ASK3HPAitx0AIrceACK3H0AixxzwIscdACLH
+					HgAixx9AItcc8CLXHQAi1x4AItcfQCLnHJAi
+					5x1hIuceSyLnHwEi9xzwIvcdACL3HgAi9x9A
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7160,7 +9605,11 @@
 					<key>CodecID</key>
 					<integer>351359253</integer>
 					<key>ConfigData</key>
-					<data>AWccQAFnHRABZx4hAWcfAQF3HBABdx0BAXceFwF3H5ABhxzwAYcdAAGHHgABhx9AAZccMAGXHRABlx6BAZcfAQGnHCABpx0BAacepwGnH5A=</data>
+					<data>
+					AWccQAFnHRABZx4hAWcfAQF3HBABdx0BAXce
+					FwF3H5ABhxzwAYcdAAGHHgABhx9AAZccMAGX
+					HRABlx6BAZcfAQGnHCABpx0BAacepwGnH5A=
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7174,7 +9623,11 @@
 					<key>CodecID</key>
 					<integer>283902597</integer>
 					<key>ConfigData</key>
-					<data>AUccEAFHHQEBRx4XAUcfmQFHDAICFxwgAhcdEAIXHiECFx8EAhcMAgEnHDABJx0BAScepgEnH5kBlxxAAZcdEAGXHoEBlx8B</data>
+					<data>
+					AUccEAFHHQEBRx4XAUcfmQFHDAICFxwgAhcd
+					EAIXHiECFx8EAhcMAgEnHDABJx0BAScepgEn
+					H5kBlxxAAZcdEAGXHoEBlx8B
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
@@ -7192,7 +9645,11 @@
 					<key>CodecID</key>
 					<integer>283902613</integer>
 					<key>ConfigData</key>
-					<data>ASccEAEnHQEBJx6mAScfmQFHHEABRx0BAUceFwFHH5kBlxwgAZcdEAGXHoEBlx8AAhccUAIXHRACFx4hAhcfAAFHDAICFwwC</data>
+					<data>
+					ASccEAEnHQEBJx6mAScfmQFHHEABRx0BAUce
+					FwFHH5kBlxwgAZcdEAGXHoEBlx8AAhccUAIX
+					HRACFx4hAhcfAAFHDAICFwwC
+					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>


### PR DESCRIPTION
These two codecs previously required CodeCommander.kext to have working microphones, this PR fixes that dependency so these two codecs work without it now.

- Updated ConfigData & Added WakeConfigData to fix CX20751/2 LineIn
- Updated ConfigData & Updated WakeConfigData to fix ALC221 LineIn(s)