### PR TITLE
Fix Headphone NodeID ALC269VC Veritron Z4640G

### DIFF
--- a/Resources/ALC269/Platforms22.xml
+++ b/Resources/ALC269/Platforms22.xml
@@ -192,7 +192,7 @@
 									<false/>
 								</dict>
 								<key>NodeID</key>
-								<integer>21</integer>
+								<integer>27</integer>
 							</dict>
 							<dict>
 								<key>Amp</key>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -2742,15 +2742,14 @@
 					<key>ConfigData</key>
 					<data>
 					AaccEAGnHQABpx4XAacfkAGXHDABlx0QAZce
-					gQGXHwABJxxAAScdAAEnHqABJx+QAVccUAFX
-					HRABVx4hAVcfAA==
+					gQGXHwABJxxAAScdAAEnHqABJx+QAbccUAG3
+					HRABtx4hAbcfAA==
 					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
 					<integer>22</integer>
 				</dict>
-				<dict>
 					<key>AFGLowPowerState</key>
 					<data>AwAAAA==</data>
 					<key>Codec</key>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -2750,6 +2750,7 @@
 					<key>LayoutID</key>
 					<integer>22</integer>
 				</dict>
+				<dict>
 					<key>AFGLowPowerState</key>
 					<data>AwAAAA==</data>
 					<key>Codec</key>


### PR DESCRIPTION
Fix Headphone NodeID ALC269VC Veritron Z4640G by Andres ZeroCross