### PR TITLE
added wakeconfigdata for ALC230

### DIFF
--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -691,6 +691,12 @@
 					<integer>1</integer>
 					<key>LayoutID</key>
 					<integer>20</integer>
+				<key>WakeConfigData</key>
+					<data>
+					AZcHJQ==
+					</data>
+					<key>WakeVerbReinit</key>
+					<true/>
 				</dict>
 				<dict>
 					<key>AFGLowPowerState</key>


### PR DESCRIPTION
added wakeconfigdata for ALC230 into Resources/PinConfigs.kext/Contents/Info.plist 
to fix sleep after wake for headphone Linein with battery