### PR TITLE
Add patch to fix internal mic gain adjustment

### DIFF
--- a/Resources/CX8050/Info.plist
+++ b/Resources/CX8050/Info.plist
@@ -163,6 +163,34 @@
 			<key>Replace</key>
 			<data>Y2ltaes=</data>
 		</dict>
+		<dict>
+			<key>Count</key>
+			<integer>1</integer>
+			<key>Find</key>
+			<data>D7bCg/kD</data>
+			<key>MinKernel</key>
+			<string>14</string>
+			<key>Name</key>
+			<string>AppleHDA</string>
+			<key>Provider</key>
+			<string>Vasishath Kaushal</string>
+			<key>Replace</key>
+			<data>D7bCg/kB</data>
+		</dict>
+		<dict>
+			<key>Count</key>
+			<integer>1</integer>
+			<key>Find</key>
+			<data>D7fwg/oC</data>
+			<key>MinKernel</key>
+			<string>14</string>
+			<key>Name</key>
+			<string>AppleHDA</string>
+			<key>Provider</key>
+			<string>Vasishath Kaushal</string>
+			<key>Replace</key>
+			<data>D7fwg/oB</data>
+		</dict>
 	</array>
 	<key>Vendor</key>
 	<string>Conexant</string>


### PR DESCRIPTION
The CX8050 has an implicit audio selector in Audio Input nodes 0x13 and 0x14 with 3 connections, each having one input amplifier. The internal mic is connected to connection index 1 of node 0x13. To adjust the internal mic gain, volume of amplifier index 1 has to be changed. 

According to intel HDA spec, multiple connections are only valid for Mixer and Selector nodes. Hence, the Apple HDA driver adjusts amp gain only for the first index of input node.

This patch modifies the driver to include connection index for input node as well while adjusting gain which fixes the issue.