### PR TITLE
Fix combojack Line-In for ALC236 layout-54 (Dell Inspiron 5488)

### DIFF
--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -1342,10 +1342,10 @@
 					<integer>283902518</integer>
 					<key>ConfigData</key>
 					<data>
-					ASccQAEnHQEBJx6mAScfkAE3HPABNx0AATce
+					ASccMAEnHQEBJx6mAScfkAE3HPABNx0AATce
 					AAE3H0ABRxwQAUcdAQFHHhcBRx+QAUcMAgGH
-					HPABhx0AAYceAAGHH0ABlxzwAZcdEQGXHhEB
-					lx9BAacc8AGnHQABpx4AAacfQAG3HPABtx0A
+					HPABhx0AAYceAAGHH0ABlxxAAZcdEAGXHoEB
+					lx8CAacc8AGnHQABpx4AAacfQAG3HPABtx0A
 					AbceAAG3H0AB1xzwAdcdAAHXHgAB1x9AAecc
 					8AHnHQAB5x4AAecfQAIXHCACFx0QAhceIQIX
 					HwICFwwC


### PR DESCRIPTION
@daggeryu, who created this particular layout, suggested me a custom AppleALC [here](https://github.com/daggeryu/DELL-Inspiron_5488_5480_5580_5482_5582_Hackintosh/issues/36#issuecomment-639532209) as a fix for this problem. I took a look at the fix to see what were the differences and I've built the most recent AppleALC with these changes. Layout-54 can now be properly used for Line-In from the combojack.