### PR TITLE
Add Icelake Smart Sound Technology Audio Controller

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1052,5 +1052,40 @@
 		<key>Vendor</key>
 		<string>Intel</string>
 	</dict>
+	<dict>
+		<key>Device</key>
+		<integer>13512</integer>
+		<key>Name</key>
+		<string>Icelake Smart Sound Technology Audio Controller</string>
+		<key>Patches</key>
+		<array>
+			<dict>
+				<key>Count</key>
+				<integer>6</integer>
+				<key>Find</key>
+				<data>cKEAAA==</data>
+				<key>MinKernel</key>
+				<integer>17</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>yDQAAA==</data>
+			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>hoBwoQ==</data>
+				<key>MinKernel</key>
+				<integer>17</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>hoDINA==</data>
+			</dict>
+		</array>
+		<key>Vendor</key>
+		<string>Intel</string>
+	</dict>
 </array>
 </plist>

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1065,7 +1065,7 @@
 				<key>Find</key>
 				<data>cKEAAA==</data>
 				<key>MinKernel</key>
-				<integer>17</integer>
+				<integer>19</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>
@@ -1077,7 +1077,7 @@
 				<key>Find</key>
 				<data>hoBwoQ==</data>
 				<key>MinKernel</key>
-				<integer>17</integer>
+				<integer>19</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>


### PR DESCRIPTION
According to https://github.com/torvalds/linux/commit/491f833134ac474434e1c950925c58b2ac13ca72, the Ice Lake audio controller is still based on Skylake feature set. Currently waiting for feedback.