### PR TITLE
Corrects 400 series PCH-LP

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1014,27 +1014,15 @@
 		<array>
 			<dict>
 				<key>Count</key>
-				<integer>6</integer>
-				<key>Find</key>
-				<data>cKEAAA==</data>
-				<key>MinKernel</key>
-				<integer>19</integer>
-				<key>Name</key>
-				<string>AppleHDAController</string>
-				<key>Replace</key>
-				<data>yAIAAA==</data>
-			</dict>
-			<dict>
-				<key>Count</key>
 				<integer>1</integer>
 				<key>Find</key>
-				<data>hoBwoQ==</data>
+				<data>DgAAvgIAAABIid8=</data>
 				<key>MinKernel</key>
 				<integer>19</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>
-				<data>hoDIAg==</data>
+				<data>DgAAuHCdAADrBpA=</data>
 			</dict>
 		</array>
 		<key>Vendor</key>


### PR DESCRIPTION
Patch based on this commit: 9c84c655f86b4c46e077538f85c19459dcdad8de (Thanks @lvs1974!)

Corrects PCH-LP audio with 02C8 mobile controllers, tested and working on my Yoga (10th gen Comet Lake).