### PR TITLE
Add 0xA3F0 device in 400 series chipsets

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -984,6 +984,41 @@
 	</dict>
 	<dict>
 		<key>Device</key>
+		<integer>41968</integer>
+		<key>Name</key>
+		<string>400 Series(0xA3F0) PCH HD Audio</string>
+		<key>Patches</key>
+		<array>
+			<dict>
+				<key>Count</key>
+				<integer>6</integer>
+				<key>Find</key>
+				<data>cKEAAA==</data>
+				<key>MinKernel</key>
+				<integer>19</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>8KMAAA==</data>
+			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>hoBwoQ==</data>
+				<key>MinKernel</key>
+				<integer>19</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>hoDwow==</data>
+			</dict>
+		</array>
+		<key>Vendor</key>
+		<string>Intel</string>
+	</dict>
+	<dict>
+		<key>Device</key>
 		<integer>1736</integer>
 		<key>Name</key>
 		<string>400 Series PCH HD Audio</string>


### PR DESCRIPTION
Some 400 series chipsets' device is `0xA3F0`

There are four chipsets with 0xA3F0 device that I know:
- MSI H410M(-A) PRO
- MSI MAG B460M MORTAR (WIFI)
- ASRock B460M Pro4
- ONDA B460SD4

![image](https://user-images.githubusercontent.com/39483078/89790809-0f15a000-db55-11ea-82e2-324adb76ce3b.png)

It's tested and working on my MSI H410M-A PRO.

