### PR TITLE
Fix LayoutId 21 for ALC285 on X1C6 (by @fewtarius)

### DIFF
--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -4696,14 +4696,14 @@
 					<data>
 					ASccEAEnHQEBJx6mAScfkAFHHDABRx0BAUce
 					FwFHH5ABlxwAAZcdEAGXHosBlx8EAhccIAIX
-					HRACFx4rAhcfBAFHDAI=
+					HRACFx4rAhcfBAFHDAICFwwC
 					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
 					<integer>21</integer>
 					<key>WakeConfigData</key>
-					<data>AUcMAg==</data>
+					<data>AUcMAgIXDAIBlwcl</data>
 					<key>WakeVerbReinit</key>
 					<true/>
 				</dict>


### PR DESCRIPTION
- Corrects the configuration needed for the ALC285 on the Lenovo X1 Carbon Gen 6 (X1C6) to eliminate "scratchy" audio, fix jacksense, and audio on wake from sleep as described and tested here: https://github.com/tylernguyen/x1c6-hackintosh/issues/75

Most work & credit by & to @fewtarius who did the work and gave hope to some poor hackintoshers out there! 👍 
