### PR TITLE
Ice Lake patch - Resolves no audio issues for multiple users.

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1072,30 +1072,6 @@
 		<array>
 			<dict>
 				<key>Count</key>
-				<integer>6</integer>
-				<key>Find</key>
-				<data>cKEAAA==</data>
-				<key>MinKernel</key>
-				<integer>19</integer>
-				<key>Name</key>
-				<string>AppleHDAController</string>
-				<key>Replace</key>
-				<data>yDQAAA==</data>
-			</dict>
-			<dict>
-				<key>Count</key>
-				<integer>1</integer>
-				<key>Find</key>
-				<data>hoBwoQ==</data>
-				<key>MinKernel</key>
-				<integer>19</integer>
-				<key>Name</key>
-				<string>AppleHDAController</string>
-				<key>Replace</key>
-				<data>hoDINA==</data>
-			</dict>
-			<dict>
-				<key>Count</key>
 				<integer>1</integer>
 				<key>Find</key>
 				<data>DgAAvgIAAABIid8=</data>

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1094,6 +1094,18 @@
 				<key>Replace</key>
 				<data>hoDINA==</data>
 			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>DgAAvgIAAABIid8=</data>
+				<key>MinKernel</key>
+				<integer>19</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>DgAAuHCdAADrBpA=</data>
+			</dict>
 		</array>
 		<key>Vendor</key>
 		<string>Intel</string>


### PR DESCRIPTION
This fix resolves a no audio issue for a few people with Ice Lake laptops.  I don't have the hardware to test this myself, but I have received multiple confirmations that it's working including input from @m0d16l14n1, @Ardentwheel, and a thread on [InsanelyMac](https://www.insanelymac.com/forum/topic/345440-applealc-alc289-on-ice-lake-dell-7390-2-in-1-i7-1065g7-with-patch-from-fewtarius-works/).  This is the same patch @lvs1974 created for Comet Lake, simply applied to the Ice Lake controller.  Also pinging @zhen-zen for feedback, as I want to make sure this doesn't accidentally break something with Ice Lake.  Before issuing a pull request I wanted to make sure it was working on at least two different model devices, we've confirmed success with two Hasee X57S1 laptops, and a Dell 7390.

