### PR TITLE
[CX20751_2] Fixed mic gain slider in Big Sur

### DIFF
--- a/Resources/CX20751_2/Info.plist
+++ b/Resources/CX20751_2/Info.plist
@@ -197,6 +197,34 @@
 			<key>Replace</key>
 			<data>D7fwg/oB</data>
 		</dict>
+		<dict>
+			<key>Count</key>
+			<integer>1</integer>
+			<key>Find</key>
+			<data>D7bqg/gD</data>
+			<key>MinKernel</key>
+			<string>20</string>
+			<key>Name</key>
+			<string>AppleHDA</string>
+			<key>Provider</key>
+			<string>Vasishath Kaushal - Ported to Big Sur by Luca91</string>
+			<key>Replace</key>
+			<data>D7bqg/gB</data>
+		</dict>
+		<dict>
+			<key>Count</key>
+			<integer>1</integer>
+			<key>Find</key>
+			<data>weEIRTHkg/gC</data>
+			<key>MinKernel</key>
+			<string>20</string>
+			<key>Name</key>
+			<string>AppleHDA</string>
+			<key>Provider</key>
+			<string>Vasishath Kaushal - Ported to Big Sur by Luca91</string>
+			<key>Replace</key>
+			<data>weEIRTHkg/gB</data>
+		</dict>
 	</array>
 	<key>Revisions</key>
 	<array>


### PR DESCRIPTION
Unfortunately Vasishath's patches to fix microphone gain slider no longer work in Big Sur.
I checked what's changed using IDA and ported these patches to work in Big Sur.
Now the microphone gain slider works again :)

NOTE: this is relevant only for CX20751_2 and Big Sur.

Thanks and happy new year,
Luca