### PR TITLE
Fix jack alc298 layout22

### DIFF
--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -6081,7 +6081,7 @@
 					<key>AFGLowPowerState</key>
 					<data>AwAAAA==</data>
 					<key>Codec</key>
-					<string>Razer Blade 14 2017 by Andres ZeroCross</string>
+					<string>Razer Blade 14 2017 by Andres ZeroCross - fixed jack for Thinkpad T470 20JN by Yattoz</string>
 					<key>CodecID</key>
 					<integer>283902616</integer>
 					<key>ConfigData</key>
@@ -6092,14 +6092,14 @@
 					lxzwAZcdAAGXHgABlx9AAacc8AGnHQABpx4A
 					AacfQAHXHPAB1x0AAdceAAHXH0AB5xzwAecd
 					AAHnHgAB5x9AAfcc8AH3HQAB9x4AAfcfQAIX
-					HCACFx0QAhceIQIXHwMBRwwC
+					HCACFx0QAhceIQIXHwMBRwwCAXcMAg==
 					</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
 					<integer>22</integer>
 					<key>WakeConfigData</key>
-					<data>AUcMAg==</data>
+					<data>AUcMAgF3DAIBhwcl</data>
 					<key>WakeVerbReinit</key>
 					<true/>
 				</dict>


### PR DESCRIPTION
I completed the jack sense pin layout for Layout 22 of ALC298, and as I was suggested to make a PR for it, here it is. 
I followed the guide presented here : https://gist.github.com/fewtarius/0ee689cf725c27c43af0aea83b04b882
And I have been using this pin layout for several weeks now, I didn't see any issue with my headphone jack and sleep in all configurations (putting it, removing it while sleeping, re-inserting it while sleeping, etc), so I think it's okay.