### PR TITLE
Add controller patch for 100 Series (8086:A170) controller

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1123,5 +1123,30 @@
 		<key>Vendor</key>
 		<string>Intel</string>
 	</dict>
+	<dict>
+		<key>Device</key>
+		<integer>41328</integer>
+		<key>Name</key>
+		<string>100 Series (0xA170) Mobile PCH HD Audio</string>
+		<key>Patches</key>
+		<array>
+			<dict>
+				<key>Comment</key>
+				<string>Patches AppleHDAController PCI ID check to always return 9D70 to enable HDMI audio</string>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>DgAAvgIAAABIid8=</data>
+				<key>MinKernel</key>
+				<integer>19</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>DgAAuHCdAADrBpA=</data>
+			</dict>
+		</array>
+		<key>Vendor</key>
+		<string>Intel</string>
+	</dict>
 </array>
 </plist>

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1132,7 +1132,7 @@
 		<array>
 			<dict>
 				<key>Comment</key>
-				<string>Patches AppleHDAController PCI ID check to always return 9D70 to enable HDMI audio</string>
+				<string>Patches out AppleHDAController PCI ID check and replaces internal variable content with 9D70 to enable HDMI audio</string>
 				<key>Count</key>
 				<integer>1</integer>
 				<key>Find</key>

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1138,7 +1138,7 @@
 				<key>Find</key>
 				<data>DgAAvgIAAABIid8=</data>
 				<key>MinKernel</key>
-				<integer>19</integer>
+				<integer>15</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>


### PR DESCRIPTION
Although this controller is supported, we need a patch to enable HDMI audio.