### PR TITLE
Fixed HDMI Audio 0xA171 for Acer VX5-591G

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -937,6 +937,18 @@
 				<key>Replace</key>
 				<data>hoBxoQ==</data>
 			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>DgAAvgIAAABIid8=</data>
+				<key>MinKernel</key>
+				<integer>19</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>DgAAuHCdAADrBpA=</data>
+			</dict>
 		</array>
 		<key>Vendor</key>
 		<string>Intel</string>


### PR DESCRIPTION
Hello,
My device (Acer VX5-591G) with device-id 0xA171 need a patch that replace `0E0000BE020000004889DF` to `0E0000B8709D0000EB0690` for HDMI audio to work.