### PR TITLE
Remove redundant 8086:A171 controller patches

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -912,40 +912,16 @@
 		<key>Model</key>
 		<string>Laptop</string>
 		<key>Name</key>
-		<string>200 Series Mobile PCH HD Audio</string>
+		<string>200 Series (0xA171) Mobile PCH HD Audio</string>
 		<key>Patches</key>
 		<array>
-			<dict>
-				<key>Count</key>
-				<integer>6</integer>
-				<key>Find</key>
-				<data>cKEAAA==</data>
-				<key>MinKernel</key>
-				<integer>16</integer>
-				<key>Name</key>
-				<string>AppleHDAController</string>
-				<key>Replace</key>
-				<data>caEAAA==</data>
-			</dict>
-			<dict>
-				<key>Count</key>
-				<integer>1</integer>
-				<key>Find</key>
-				<data>hoBwoQ==</data>
-				<key>MinKernel</key>
-				<integer>16</integer>
-				<key>Name</key>
-				<string>AppleHDAController</string>
-				<key>Replace</key>
-				<data>hoBxoQ==</data>
-			</dict>
 			<dict>
 				<key>Count</key>
 				<integer>1</integer>
 				<key>Find</key>
 				<data>DgAAvgIAAABIid8=</data>
 				<key>MinKernel</key>
-				<integer>19</integer>
+				<integer>15</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>


### PR DESCRIPTION
This matches the controller patch for 8086:A170. I only tested this on macOS 11/12, but the find pattern is present in 10.11's AppleHDAController binary.