### PR TITLE
Add front panel connections layout 23 -  ALC892 ASRock B365 Pro4

### DIFF
--- a/Resources/ALC892/Platforms23.xml
+++ b/Resources/ALC892/Platforms23.xml
@@ -17,6 +17,8 @@
 	<key>PathMaps</key>
 	<array>
 		<dict>
+			<key>Comment</key>
+			<string>ALC892 for ASRock B365 Pro4 By TheHackGuy</string>
 			<key>PathMap</key>
 			<array>
 				<array>
@@ -113,8 +115,122 @@
 					<array>
 						<array>
 							<dict>
+								<key>Amp</key>
+								<dict>
+									<key>Channels</key>
+									<array>
+										<dict>
+											<key>Bind</key>
+											<integer>1</integer>
+											<key>Channel</key>
+											<integer>1</integer>
+										</dict>
+										<dict>
+											<key>Bind</key>
+											<integer>2</integer>
+											<key>Channel</key>
+											<integer>2</integer>
+										</dict>
+									</array>
+									<key>MuteInputAmp</key>
+									<true/>
+									<key>PublishMute</key>
+									<true/>
+									<key>PublishVolume</key>
+									<true/>
+									<key>VolumeInputAmp</key>
+									<true/>
+								</dict>
+								<key>NodeID</key>
+								<integer>9</integer>
+							</dict>
+							<dict>
+								<key>NodeID</key>
+								<integer>34</integer>
+							</dict>
+							<dict>
+								<key>NodeID</key>
+								<integer>25</integer>
+							</dict>
+						</array>
+					</array>
+				</array>
+				<array>
+					<array>
+						<array>
+							<dict>
 								<key>NodeID</key>
 								<integer>20</integer>
+							</dict>
+							<dict>
+								<key>Amp</key>
+								<dict>
+									<key>Channels</key>
+									<array>
+										<dict>
+											<key>Bind</key>
+											<integer>1</integer>
+											<key>Channel</key>
+											<integer>1</integer>
+										</dict>
+										<dict>
+											<key>Bind</key>
+											<integer>2</integer>
+											<key>Channel</key>
+											<integer>2</integer>
+										</dict>
+									</array>
+									<key>MuteInputAmp</key>
+									<true/>
+									<key>PublishMute</key>
+									<true/>
+									<key>PublishVolume</key>
+									<true/>
+									<key>VolumeInputAmp</key>
+									<false/>
+								</dict>
+								<key>NodeID</key>
+								<integer>12</integer>
+							</dict>
+							<dict>
+								<key>Amp</key>
+								<dict>
+									<key>Channels</key>
+									<array>
+										<dict>
+											<key>Bind</key>
+											<integer>1</integer>
+											<key>Channel</key>
+											<integer>1</integer>
+										</dict>
+										<dict>
+											<key>Bind</key>
+											<integer>2</integer>
+											<key>Channel</key>
+											<integer>2</integer>
+										</dict>
+									</array>
+									<key>MuteInputAmp</key>
+									<true/>
+									<key>PublishMute</key>
+									<true/>
+									<key>PublishVolume</key>
+									<true/>
+									<key>VolumeInputAmp</key>
+									<false/>
+								</dict>
+								<key>NodeID</key>
+								<integer>2</integer>
+							</dict>
+						</array>
+					</array>
+				</array>
+				<array>
+					<array>
+						<array>
+							<dict>
+								<key>NodeID</key>
+								<integer>27</integer>
 							</dict>
 							<dict>
 								<key>Amp</key>

--- a/Resources/ALC892/layout23.xml
+++ b/Resources/ALC892/layout23.xml
@@ -1,6 +1,6 @@
 <dict>
-    <key>Comment</key>
-    <string>ALC892 for ASRock B365 Pro4 By TheHackGuy</string>
+	<key>Comment</key>
+	<string>ALC892 for ASRock B365 Pro4 By TheHackGuy</string>
 	<key>LayoutID</key>
 	<integer>23</integer>
 	<key>PathMapRef</key>

--- a/Resources/ALC892/layout23.xml
+++ b/Resources/ALC892/layout23.xml
@@ -1,4 +1,6 @@
 <dict>
+    <key>Comment</key>
+    <string>ALC892 for ASRock B365 Pro4 By TheHackGuy</string>
 	<key>LayoutID</key>
 	<integer>23</integer>
 	<key>PathMapRef</key>
@@ -8,6 +10,8 @@
 			<array>
 				<integer>283904146</integer>
 			</array>
+			<key>Headphone</key>
+			<dict/>
 			<key>Inputs</key>
 			<array>
 				<string>Mic</string>
@@ -596,6 +600,7 @@
 			<key>Outputs</key>
 			<array>
 				<string>LineOut</string>
+				<string>Headphone</string>
 			</array>
 			<key>PathMapID</key>
 			<integer>23</integer>

--- a/Resources/ALC892/layout23.xml
+++ b/Resources/ALC892/layout23.xml
@@ -20,7 +20,7 @@
 			<key>LineIn</key>
 			<dict>
 				<key>MuteGPIO</key>
-				<integer>1342242842</integer>
+				<integer>1342242841</integer>
 			</dict>
 			<key>LineOut</key>
 			<dict/>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -6600,7 +6600,7 @@
 					<key>Comment</key>
 					<string>ALC892 for ASRock B365 Pro4 By TheHackGuy</string>
 					<key>ConfigData</key>
-					<data>AUccEAFHHUABRx4BAUcfAQFHDAIBhxwgAYcdkAGHHqABhx+BAaccMAGnHTABpx6BAacfAQ==</data>
+					<data>AUccEAFHHUABRx4BAUcfAQFHDAIBhxwgAYcdkAGHHqABhx+BAaccMAGnHTABpx6BAacfAQGXHEABlx2QAZcegQGXHwIBtxxQAbcdQAG3HiEBtx8CAbcMAg==</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>


### PR DESCRIPTION
Platfoms.xml:
- Add front panel connections
- Add comment

Layout.xml:
- Add Headphone
- Add comment

PinConfigs:
- Add node 25 for line in and node 27 for HP out. Used for the front-panel combo-jack port.

Tested on macOS 12.1



Thanks to all AppleALC devs