### PR TITLE
Replace 200 Series (0xA2F0) PCH HD Audio patch.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 AppleALC Changelog
 ==================
+#### v1.6.8
+- Replace patch for 500 Series(0x43C8) PCH HD Audio
+
 #### v1.6.7
 - Added 600-series controller patch by @R-a-s-c-a-l
 - Added ALC282 layout-id 69 for Lenovo IdeaPad Z510 by hoseinrez

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ AppleALC Changelog
 ==================
 #### v1.6.8
 - Replace patch for 500 Series(0x43C8) PCH HD Audio
+- Replace patch for 200 Series(0xA2F0) PCH HD Audio
 
 #### v1.6.7
 - Added 600-series controller patch by @R-a-s-c-a-l

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1249,27 +1249,15 @@
 		<array>
 			<dict>
 				<key>Count</key>
-				<integer>6</integer>
-				<key>Find</key>
-				<data>cKEAAA==</data>
-				<key>MinKernel</key>
-				<integer>19</integer>
-				<key>Name</key>
-				<string>AppleHDAController</string>
-				<key>Replace</key>
-				<data>yEMAAA==</data>
-			</dict>
-			<dict>
-				<key>Count</key>
 				<integer>1</integer>
 				<key>Find</key>
-				<data>hoBwoQ==</data>
+				<data>DgAAvgIAAABIid8=</data>
 				<key>MinKernel</key>
 				<integer>19</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>
-				<data>hoDIQw==</data>
+				<data>DgAAuHCdAADrBpA=</data>
 			</dict>
 		</array>
 		<key>Vendor</key>

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -996,32 +996,20 @@
 		<key>Device</key>
 		<integer>41712</integer>
 		<key>Name</key>
-		<string>200 Series PCH HD Audio</string>
+		<string>200 Series (0xA2F0) PCH HD Audio</string>
 		<key>Patches</key>
 		<array>
 			<dict>
 				<key>Count</key>
-				<integer>6</integer>
-				<key>Find</key>
-				<data>cKEAAA==</data>
-				<key>MinKernel</key>
-				<integer>16</integer>
-				<key>Name</key>
-				<string>AppleHDAController</string>
-				<key>Replace</key>
-				<data>8KIAAA==</data>
-			</dict>
-			<dict>
-				<key>Count</key>
 				<integer>1</integer>
 				<key>Find</key>
-				<data>hoBwoQ==</data>
+				<data>DgAAvgIAAABIid8=</data>
 				<key>MinKernel</key>
-				<integer>16</integer>
+				<integer>19</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>
-				<data>hoDwog==</data>
+				<data>DgAAuHCdAADrBpA=</data>
 			</dict>
 		</array>
 		<key>Vendor</key>

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1009,7 +1009,7 @@
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>
-				<data>DgAAuHCdAADrBpA=</data>
+				<data>DgAAuHChAADrBpA=</data>
 			</dict>
 		</array>
 		<key>Vendor</key>

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1005,7 +1005,7 @@
 				<key>Find</key>
 				<data>DgAAvgIAAABIid8=</data>
 				<key>MinKernel</key>
-				<integer>19</integer>
+				<integer>16</integer>
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>


### PR DESCRIPTION
Stop using the ugly way of patching pci id checks. 

Tested and confirmed working on macOS 12.1

Lilu debug log attached:
[Lilu_1.5.8_21.2.txt](https://github.com/acidanthera/AppleALC/files/7773736/Lilu_1.5.8_21.2.txt)

Screenshot from ioreg which shows 0xA2F0 device id:
![Screen Shot 2021-12-24 at 10 38 45](https://user-images.githubusercontent.com/62154074/147341043-84640fb8-9560-4e41-9486-739159f05a4c.png)




@vandroiy2013 Do you think it's needed to test this patch on older version then 12.1?

