### PR TITLE
Fix Legion Y9000X Speaker Mute disabled issue

### DIFF
--- a/Resources/ALC285/Platforms66.xml
+++ b/Resources/ALC285/Platforms66.xml
@@ -170,7 +170,7 @@
 								<key>Amp</key>
 								<dict>
 									<key>MuteInputAmp</key>
-									<true/>
+									<false/>
 									<key>PublishMute</key>
 									<true/>
 									<key>PublishVolume</key>
@@ -219,7 +219,7 @@
 								<key>Amp</key>
 								<dict>
 									<key>MuteInputAmp</key>
-									<true/>
+									<false/>
 									<key>PublishMute</key>
 									<true/>
 									<key>PublishVolume</key>


### PR DESCRIPTION
This is an attempt to fix the mute of `Internal Speaker` is disabled (while the hardware supports it).

This is still a draft PR, Tests are needed.

Precompiled kext of the PR:

[AppleALC.kext.zip](https://github.com/acidanthera/AppleALC/files/7867630/AppleALC.kext.zip)

Audio device info:

[codec#0.txt](https://github.com/acidanthera/AppleALC/files/7867632/codec.0.txt)
[snd_codec_realtek.txt](https://github.com/acidanthera/AppleALC/files/7867633/snd_codec_realtek.txt)

