### PR TITLE
Update 0xA2F0 controller patch to fix HDMI audio

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -985,7 +985,7 @@
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>
-				<data>DgAAuHCdAADrBpA=</data>
+				<data>DgAAuHChAADrBpA=</data>
 			</dict>
 		</array>
 		<key>Vendor</key>


### PR DESCRIPTION
Setting the device-id to 0x9D70 doesn't work with HDMI audio. This commit replaces 0x9D70 with 0xA170 which will also fix HDMI audio. The original patch also used 0xA170.

See:
https://github.com/acidanthera/AppleALC/pull/748#issuecomment-1001042590
https://github.com/acidanthera/AppleALC/commit/d3715e08e954e1214d280ac1efbe08159f204007#commitcomment-65861080