### PR TITLE
Update alc-verb param passing & layout of verb log

### DIFF
--- a/AppleALC/kern_alc.cpp
+++ b/AppleALC/kern_alc.cpp
@@ -384,7 +384,13 @@ bool AlcEnabler::AppleHDAController_start(IOService* service, IOService* provide
 
 IOReturn AlcEnabler::IOHDACodecDevice_executeVerb(void *hdaCodecDevice, uint16_t nid, uint16_t verb, uint16_t param, unsigned int *output, bool waitForSuccess)
 {
-	DBGLOG("alc", "IOHDACodecDevice::executeVerb with parameters nid = %u, verb = %u, param = %u", nid, verb, param);
+	if (verb & 0xff0) {
+		// 12 bit verb
+		DBGLOG("alc", "IOHDACodecDevice::executeVerb with parameters nid = 0x%02X, verb = 0x%03X, param = 0x%02X", nid, verb, param);
+	} else {
+		// 4 bit verb
+		DBGLOG("alc", "IOHDACodecDevice::executeVerb with parameters nid = 0x%02X, verb = 0x%X, param = 0x%04X", nid, verb, param);
+	}
 	return FunctionCast(IOHDACodecDevice_executeVerb, callbackAlc->orgIOHDACodecDevice_executeVerb)(hdaCodecDevice, nid, verb, param, output, waitForSuccess);
 }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ AppleALC Changelog
 - Updated pinconfig ALC897 layout-id 12 by @Sergey-Galan
 - Replace 200 Series PCH HD Audio 0xA2F0 controller patch
 - Update 0xA2F0 controller patch to fix HDMI audio by Core-i99
+- Improved compatibility of `alc-verb` with Linux `hda-verb`
 
 #### v1.6.8
 - Replace patch for 500 Series(0x43C8) PCH HD Audio

--- a/alc-verb/main.c
+++ b/alc-verb/main.c
@@ -156,7 +156,15 @@ static unsigned execute_command(unsigned dev, uint16_t nid, uint16_t verb, uint1
 	uint32_t inputCount = 3;	// Must match the declaration in ALCUserClient::sMethods
 	uint64_t input[inputCount];
 	input[0]	= nid;
-	input[1]	= verb;
+	// Convert Unix-style 4 bit verbs 0xn00 to Intel-style 4 bit verbs 0xn which Apple methods also
+	// use internally, to avoid IOHDACodecDevice_executeVerb discarding the top 8 bits of param.
+	if (verb & 0xff) {
+		// 12 bit verb
+		input[1]	= verb;
+	} else {
+		// 4 bit verb
+		input[1]	= verb >> 8;
+	}
 	input[2]	= param;
 	
 	uint64_t output;


### PR DESCRIPTION
So I got the the bottom of the alc-verb issue.

The Intel HDA spec, and Apple's IOHDACodecDevice::executeVerb (and AudioDxe) all pass 4 bit verbs (0x4, 0x5, 0xC, 0xD, etc.) as 4 bits, and 12 bit verbs (0x7nn, 0xFnn) as 12 bits.

The Linux sound drivers, and Linux `alsa-tools`' `hda-verb` all represent 4 bit verbs as a 12 bit verb with 00 (0x400, 0x500, 0xC00, 0xD00, etc.).

The back end of `alc-verb` is using the Apple method, but the front end follows the Linux convention. This is not as bad as it sounds, because of the way codec verbs are eventually packed.

If we imagine using `alc-verb` or `hda-verb` to write to a 16bit processing coefficient on node 0x20 (which coefficient to use is set previously using verb 0x5, and the set value can be read afterwards using verb 0xC) with the following parameters, these are the results:

|command|hda-verb|alc-verb|modified alc-verb|
|---|---|---|--|
|0x20 SET_PROC_COEF* 0x1234|0x1234|0x34|0x1234|
|0x20 0x400 0x1234|0x1234|0x34|0x1234|
|0x20 0x412 0x34 (https://github.com/acidanthera/bugtracker/issues/1644)|0x1234|0x1234|0x1234|
|0x20 0x4 0x1234|undefined result (illegal verb)|0x1234|0x1234|

*SET_PROC_COEF is 0x400, or 0x4 depending on the convention