### PR TITLE
Fixed EAPD for layout 28 ALC269 by samcabral

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 AppleALC Changelog
 ==================
+#### v1.7.1
+- Fixed EAPD for layout 28 ALC269 by @samcabral
+
 #### v1.7.0
 - Fix headphones after sleep on Latitude 7390 2-in-1 (ALC225 layout 30)
 - Added `dump_coeff.sh` script in `Tools` to dump processing caps under macOS, plus docs in Wiki

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -2892,11 +2892,15 @@
 					<key>Comment</key>
 					<string>ALC269VC for Lenovo Z580, John</string>
 					<key>ConfigData</key>
-					<data>AVccQAFXHRABVx4hAVcfAwGHHCABhx0QAYcegQGHHwMBlxwwAZcdAQGXHqABlx+QAbccEAG3HQEBtx4XAbcfkAFXDAI=</data>
+					<data>AbccEAG3HQEBtx4XAbcfkAG3DAIBhxwgAYcdEAGHHoEBhx8DAZccMAGXHQEBlx6gAZcfkAFXHEABVx0QAVceIQFXHwMBVwwC</data>
 					<key>FuncGroup</key>
 					<integer>1</integer>
 					<key>LayoutID</key>
 					<integer>28</integer>
+					<key>WakeConfigData</key>
+					<data>AVcMAgG3DAI=</data>
+					<key>WakeVerbReinit</key>
+					<true/>
 				</dict>
 				<dict>
 					<key>AFGLowPowerState</key>


### PR DESCRIPTION
Changes

- Add EAPD support for speakers (Node 0x1b)
- Add WakeConfigData and WakeVerbReinit missing

Speakers audio works after sleep.