### PR TITLE
Fix hdmi audio for 400 series 0x06C8 HD audio

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ AppleALC Changelog
 ==================
 #### v1.7.2
 - Added layout-id 97 ALC257 for Lenovo Thinkpad T490 by @savvamitrofanov
+- Update controller patch for 400 series 0x06C8 to fix HDMI audio by @Core-i99
 
 #### v1.7.1
 - Fixed EAPD for layout 28 ALC269 by @samcabral

--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1140,7 +1140,7 @@
 				<key>Name</key>
 				<string>AppleHDAController</string>
 				<key>Replace</key>
-				<data>DgAAuHCdAADrBpA=</data>
+				<data>DgAAuHChAADrBpA=</data>
 			</dict>
 		</array>
 		<key>Vendor</key>


### PR DESCRIPTION
The "old" patch sets the device id to 0x9D70 which doesn't work with HDMI audio.
This commit sets the device id to 0xA170 which also works with HDMI audio.



For more info: https://www.facebook.com/groups/hackintosch/posts/10160299439262446/
An ioreg without HDMI audio working: [jbmac.zip](https://github.com/acidanthera/AppleALC/files/8592232/jbmac.zip)


Note: 
This patch was unfortunately not tested on all macOS versions it supports (Catalina to latest macOS). Only tested on Big Sur.
I don't own this system to test all macOS versions. 

I know a new controller patch isn't supposed to get merged before testing every macOS version it supports. 
But this kind of patch was already tested on my system with 200 series (0xA2F0) HD audio, so the device id I'm setting here is indeed working and is present in the binaries.


Please comment if this can't get merged because it's not tested. I can ask to the owner of the system to test this, altrough I'm not sure if he wants to test all those macOS versions. 