### PR TITLE
Fix Legion Y9000X 2020 Speaker Mute disabled issue

### DIFF
--- a/Resources/ALC285/Platforms66.xml
+++ b/Resources/ALC285/Platforms66.xml
@@ -170,7 +170,7 @@
 								<key>Amp</key>
 								<dict>
 									<key>MuteInputAmp</key>
-									<true/>
+									<false/>
 									<key>PublishMute</key>
 									<true/>
 									<key>PublishVolume</key>
@@ -219,7 +219,7 @@
 								<key>Amp</key>
 								<dict>
 									<key>MuteInputAmp</key>
-									<true/>
+									<false/>
 									<key>PublishMute</key>
 									<true/>
 									<key>PublishVolume</key>


### PR DESCRIPTION
This is an attempt to fix the mute of Internal Speaker is disabled (while the hardware supports it).