### PR TITLE
[Controllers] Added 700 series PCH HD Audio IDs

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1308,5 +1308,28 @@
 		<key>Vendor</key>
 		<string>Intel</string>
 	</dict>
+	<dict>
+		<key>Device</key>
+		<integer>31312</integer>
+		<key>Name</key>
+		<string>700 Series(0x7A50) PCH HD Audio</string>
+		<key>Patches</key>
+		<array>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>DgAAvgIAAABIid8=</data>
+				<key>MinKernel</key>
+				<integer>19</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>DgAAuEijAADrBpA=</data>
+			</dict>
+		</array>
+		<key>Vendor</key>
+		<string>Intel</string>
+	</dict>
 </array>
 </plist>


### PR DESCRIPTION
# Specs

Tested motherboard: `Gigabyte Z790 Aorus Elite AX DDR5`
Audio Codec: `ALC897`

# How I discovered this patch

The default `device-id` of the audio controller is `0x7A50`. Without spoofing its device-id to `0x7AD0`, AppleALC doesn't even load.

Further proofs:

1. Default `0x7A50` as `device-id` (no spoof):

![image](https://user-images.githubusercontent.com/17933708/208654302-c446d06b-4352-42d3-9c92-164f40440c22.png)

2. `0x7AD0` as `device-id` spoofed via `DeviceProperties` (ignore the wrong `layout-id` as this screenshot was taken before setting the right one):

![image](https://user-images.githubusercontent.com/17933708/208654489-2de745d9-44c9-46bb-9806-9d1ff9f2c588.png)

At this point I simply copied the `600 Series(0x7AD0) PCH HD Audio` patch and replicated for the `700 series`.

# Conclusions

I'm not quite sure that's the right approach, but from what I understood from the previous commits on this repo, to add a controller, `Resources/Controllers.plist` must be edited.

I built the kext and it works, without the `DeviceProperties` `device-id` spoof, therefore I say the patch is correctly applied.

Kind regards

--
dreamwhite