### PR TITLE
 hp fury15 g7  Realtek alc285  applealc 1.8.1 ID：66

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,13 @@ jobs:
       - name: CI Bootstrap
         run: |
           src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/real-int-plist-check/ci-bootstrap.sh) && eval "$src" || exit 1
+      - name: Upload to Artifacts (Plist Integer Type Fix)
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Plist Integer Type Fix Artifacts
+          path: ./plist-int.diff
+
       - name: Lilu Bootstrap
         run: |
           src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/Lilu/master/Lilu/Scripts/bootstrap.sh) && eval "$src" || exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           path: MacKernelSDK
       - name: CI Bootstrap
         run: |
-          src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/real-int-plist-check/ci-bootstrap.sh) && eval "$src" || exit 1
       - name: Lilu Bootstrap
         run: |
           src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/Lilu/master/Lilu/Scripts/bootstrap.sh) && eval "$src" || exit 1

--- a/Resources/AD1984A/Info.plist
+++ b/Resources/AD1984A/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>MacPeet</string>
 	<key>CodecID</key>
-	<integer>6474</integer>
+	<real>6474</real>
 	<key>CodecName</key>
 	<string>AD1984A</string>
 	<key>Files</key>
@@ -16,7 +16,7 @@
 				<key>Comment</key>
 				<string>MacPeet - AD1984A</string>
 				<key>Id</key>
-				<integer>11</integer>
+				<real>11</real>
 				<key>Path</key>
 				<string>layout11.xml.zlib</string>
 			</dict>

--- a/Resources/CX8050/Info.plist
+++ b/Resources/CX8050/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>Vandroiy</string>
 	<key>CodecID</key>
-	<integer>8050</integer>
+	<real>8050</real>
 	<key>CodecName</key>
 	<string>CX8050</string>
 	<key>Files</key>
@@ -57,7 +57,7 @@
 			<key>Find</key>
 			<data>xgYASIu/aAE=</data>
 			<key>MinKernel</key>
-			<integer>18</integer>
+			<real>18</real>
 			<key>Name</key>
 			<string>AppleHDA</string>
 			<key>Replace</key>


### PR DESCRIPTION
The sound card is Realtek alc285, the sound card id is set to 66, and there is no sound for other ids. If you do not change the input of the sound preference setting, there will always be sound. If you set the input option, there will be no sound. You need to restart the system to solve it. Hope The master can help to solve this error, shield the input line input audio, thank you!

![截屏2023-05-05 16 20 17](https://user-images.githubusercontent.com/132587808/236419737-caa591f4-3e8d-4545-9faf-2d341fcfe1ba.png)
