### PR TITLE
Add GitHub Action to Check plist Files for 'real' Key

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,37 @@
+name: Check plist files for 'real' key
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  check-plist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+
+      - name: Find 'real' Key in plist files
+        run: |
+          if result=$(find . -type f -name "*.plist" -exec grep -nH "<real>[0-9]*<\/real>" {} \; 2>/dev/null); then
+            if [ -n "$result" ]; then
+              echo "::error::Found 'real' key in the following files:"
+              while read -r line; do
+                echo "$line" | awk -F: '{print $1}'; # print the file path
+                echo "$line" | awk -F: '{print ":"$2":"$3}'; # print the line number and the line
+              done <<< "$result"
+              exit 1
+            else
+              echo "No 'real' key found."
+              exit 0
+            fi
+          else
+            echo "Error occurred while searching for 'real' key."
+            exit 1
+          fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,21 +17,13 @@ jobs:
       - name: Install xmllint
         run: sudo apt-get install libxml2-utils
 
-      - name: Find 'real' Key in plist files
+      - name: Find 'real' key in plist files
         run: |
-          if result=$(find . -type f -name "*.plist" -exec grep -nH "<real>[0-9]*<\/real>" {} \; 2>/dev/null); then
-            if [ -n "$result" ]; then
-              echo "::error::Found 'real' key in the following files:"
-              while read -r line; do
-                echo "$line" | awk -F: '{print $1}'; # print the file path
-                echo "$line" | awk -F: '{print ":"$2":"$3}'; # print the line number and the line
-              done <<< "$result"
+          # Find all plist files and parse them using xmllint, searching for the 'real' key
+          for file in $(find . -type f -name "*.plist"); do
+            if xmllint --xpath "//real" "$file" 2>/dev/null; then
+              echo "::error::Found 'real' key in $file."
               exit 1
-            else
-              echo "No 'real' key found."
-              exit 0
             fi
-          else
-            echo "Error occurred while searching for 'real' key."
-            exit 1
-          fi
+          done
+          echo "No 'real' key found."

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -124,7 +124,7 @@
 					<key>Codec</key>
 					<string>agasecond - Realtek ALC256 (3246) for Xiaomi Pro Enhanced 2019</string>
 					<key>CodecID</key>
-					<int>283902550</int>
+					<integer>283902550</integer>
 					<key>ConfigData</key>
 					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAYcc8AGHHQABhx4AAYcfQAGXHEABlx0QAZceqwGXHwQBpxzwAacdAAGnHgABpx9AAbccEAG3HQEBtx4XAbcfkAG3DAIB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHDACFx0QAhceKwIXHwQCFwwCAgUAEAIEACACBQBGAgQwpA==</data>
 					<key>FuncGroup</key>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -124,7 +124,7 @@
 					<key>Codec</key>
 					<string>agasecond - Realtek ALC256 (3246) for Xiaomi Pro Enhanced 2019</string>
 					<key>CodecID</key>
-					<integer>283902550</integer>
+					<int>283902550</int>
 					<key>ConfigData</key>
 					<data>ASccIAEnHQEBJx6mAScfkAE3HPABNx0AATceAAE3H0ABRxzwAUcdAAFHHgABRx9AAYcc8AGHHQABhx4AAYcfQAGXHEABlx0QAZceqwGXHwQBpxzwAacdAAGnHgABpx9AAbccEAG3HQEBtx4XAbcfkAG3DAIB1xzwAdcdAAHXHgAB1x9AAecc8AHnHQAB5x4AAecfQAIXHDACFx0QAhceKwIXHwQCFwwCAgUAEAIEACACBQBGAgQwpA==</data>
 					<key>FuncGroup</key>
@@ -5670,7 +5670,7 @@
 					<key>Codec</key>
 					<string>Piscean - Realtek ALC298 for Dell Precision 5540</string>
 					<key>CodecID</key>
-					<real>283902616</real>
+					<integer>283902616</integer>
 					<key>ConfigData</key>
 					<data>ASccMAEnHQEBJx6gAScfkAF3HBABdx0BAXceFwF3H5ABhxxwAYcdIAGHHosBhx8CAhccIAIXHRACFx4rAhcfAwF3DAIBhwclAhcIgw==</data>
 					<key>FuncGroup</key>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -34,7 +34,9 @@
 					<key>Codec</key>
 					<string>Baio77 - ALC295 Lenovo_X1_Tablet_3°Gen</string>
 					<key>CodecID</key>
-					<real>283902613</real>
+					<real>
+                                        283902613
+                                        </real>
 					<key>ConfigData</key>
 					<data>AUccEAFHHQABRx4XAUcfkAFHDAICFxwgAhcdEAIXHiECFx8AAhcMAgEnHDABJx0AASceoAEnH5ABlxxAAZcdEAGXHoEBlx8A</data>
 					<key>FuncGroup</key>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -34,7 +34,7 @@
 					<key>Codec</key>
 					<string>Baio77 - ALC295 Lenovo_X1_Tablet_3°Gen</string>
 					<key>CodecID</key>
-					<integer>283902613</integer>
+					<real>283902613</real>
 					<key>ConfigData</key>
 					<data>AUccEAFHHQABRx4XAUcfkAFHDAICFxwgAhcdEAIXHiECFx8AAhcMAgEnHDABJx0AASceoAEnH5ABlxxAAZcdEAGXHoEBlx8A</data>
 					<key>FuncGroup</key>


### PR DESCRIPTION
This pull request introduces a GitHub Action workflow to automatically scan all `.plist` files in the repository for the presence of the `real` key. The `real` key, when found, creates issues when compiling the project, thus the need of fixing it to `integer` type.

The workflow utilizes `libxml2-utils` to parse `.plist` files and `grep` to search for occurrences of the `real` key. If the key is found in any of the plist files, the workflow will raise an error, prompting contributors to consider replacing `real` with `integer` for the above reasons.

You can test the functionality by "accidentally" replacing a `integer` key with `real`: the action will return error code `1` and print both the file name as well as the line number with the line content, for better debugging purposes.

Please review and merge this pull request to integrate the new GitHub Action into the project workflow.


CC @vandroiy2013