### PR TITLE
Fix AMD HDA Controllers on macOS Sequoia

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -481,6 +481,18 @@
 				<key>Replace</key>
 				<data>9sIBkJA=</data>
 			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>PQIQAAAPhA==</data>
+				<key>MinKernel</key>
+				<integer>24</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>PSIQAAAPjg==</data>
+			</dict>
 		</array>
 		<key>Vendor</key>
 		<string>AMDZEN</string>
@@ -532,6 +544,18 @@
 				<key>Replace</key>
 				<data>9sIBkJA=</data>
 			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>PQIQAAAPhA==</data>
+				<key>MinKernel</key>
+				<integer>24</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>PSIQAAAPjg==</data>
+			</dict>
 		</array>
 		<key>Vendor</key>
 		<string>AMDZEN</string>
@@ -582,6 +606,18 @@
 				<string>AppleHDAController</string>
 				<key>Replace</key>
 				<data>9sIBkJA=</data>
+			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>PQIQAAAPhA==</data>
+				<key>MinKernel</key>
+				<integer>24</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>PSIQAAAPjg==</data>
 			</dict>
 		</array>
 		<key>Vendor</key>


### PR DESCRIPTION
Add in a modified version of the original VendorID check patch which matches the Sequoia AppleHDAController binary

Confirmed to be working on a `1022:1457` HDA Controller (🦀)

~~I just need people to test this on `1022:1487` and `1022:15E3` IDs~~

Confirmed working on all affected HDA controllers!