### PR TITLE
Update Controllers.plist for MS01-MiniPC Raptor Lake-P/U/H cAVS Audio…

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -1426,6 +1426,29 @@
 	</dict>
 	<dict>
 		<key>Device</key>
+		<integer>20938</integer>
+		<key>Name</key>
+		<string>Raptor Lake-P/U/H cAVS Audio Controller (0x51CA)</string>
+		<key>Patches</key>
+		<array>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>DgAAvgIAAABIid8=</data>
+				<key>MinKernel</key>
+				<integer>19</integer>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>DgAAuEijAADrBpA=</data>
+			</dict>
+		</array>
+		<key>Vendor</key>
+		<string>Intel</string>
+	</dict>
+	<dict>
+		<key>Device</key>
 		<integer>31312</integer>
 		<key>Name</key>
 		<string>700 Series(0x7A50) PCH HD Audio</string>


### PR DESCRIPTION
Update Controllers.plist for MS01-MiniPC Raptor Lake-P/U/H cAVS Audio Controller by laobamac.

Remarks: This sound card is currently confirmed to be available as an imitation of 600 PCH Audio. Layout-id must be injected after imitation, because AppleALC does not have the device ID of this sound card.