### PR TITLE
Add ALC255 layout-id 16 for Gigabyte Aorus 15G (warm-reboot/sleep audio fix)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 AppleALC Changelog
 ==================
+#### v1.9.8
+- Added ALC255 layout-id 16 for Gigabyte Aorus 15G (warm-reboot/sleep audio fix) by Andergraw
+
 #### v1.9.7
 - Added ALC897 layout-id 31 for MSI X670E Gaming WIFI by yandong31
 - ALC892 changed MinKernel 13->12 by bugprogrammer

--- a/Resources/ALC255/Info.plist
+++ b/Resources/ALC255/Info.plist
@@ -22,6 +22,14 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
+				<string>Custom - Realtek ALC255 for Gigabyte Aorus 15G (warm-reboot/sleep audio fix, same as layout 3) by Andergraw</string>
+				<key>Id</key>
+				<integer>16</integer>
+				<key>Path</key>
+				<string>layout3.xml.zlib</string>
+			</dict>
+			<dict>
+				<key>Comment</key>
 				<string>ALC255 Optiplex</string>
 				<key>Id</key>
 				<integer>12</integer>
@@ -236,6 +244,14 @@
 				<string>Mirone Laptop Patch ALC255</string>
 				<key>Id</key>
 				<integer>3</integer>
+				<key>Path</key>
+				<string>PlatformsM.xml.zlib</string>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Custom - Realtek ALC255 for Gigabyte Aorus 15G (warm-reboot/sleep audio fix, same as layout 3) by Andergraw</string>
+				<key>Id</key>
+				<integer>16</integer>
 				<key>Path</key>
 				<string>PlatformsM.xml.zlib</string>
 			</dict>

--- a/Resources/PinConfigs.kext/Contents/Info.plist
+++ b/Resources/PinConfigs.kext/Contents/Info.plist
@@ -1769,6 +1769,24 @@
 					<true/>
 				</dict>
 				<dict>
+					<key>AFGLowPowerState</key>
+					<data>AwAAAA==</data>
+					<key>Codec</key>
+					<string>Custom - Realtek ALC255 for Gigabyte Aorus 15G (warm-reboot/sleep audio fix) by Andergraw</string>
+					<key>CodecID</key>
+					<integer>283902549</integer>
+					<key>ConfigData</key>
+					<data>ASccEAEnHQABJx6mAScfkAFHHCABRx0AAUceFwFHH5ABlxwwAZcdEAGXHosBlx8AAhccUAIXHRACFx4rAhcfAgFHDAICBQAQAgQAIA==</data>
+					<key>FuncGroup</key>
+					<integer>1</integer>
+					<key>LayoutID</key>
+					<integer>16</integer>
+					<key>WakeConfigData</key>
+					<data>AUcMAgIFABACBAAg</data>
+					<key>WakeVerbReinit</key>
+					<true/>
+				</dict>
+				<dict>
 					<key>Codec</key>
 					<string>ALC255 for Dell Optiplex7060/7070MT(Separate LineOut)</string>
 					<key>CodecID</key>


### PR DESCRIPTION
Adds a new custom layout (id 16) for the Realtek ALC255 on the Gigabyte Aorus 15G.

Fixes acidanthera/bugtracker#2540. Created as a **new layout** per @vandroiy2013's guidance in that thread (layouts 1–10 are reserved for Mirone/Toleda), rather than modifying the existing Mirone layout 3.

### Problem

On this laptop the speaker is silent after a **warm reboot from Windows → macOS** and after **wake from sleep** (short/medium/long). Everything enumerates correctly — the device shows up, volume keys and jack-sense work — but no sound is produced. Cold boot from power-off is unaffected.

### Cause

The Realtek vendor node (NID 0x20) keeps a processing coefficient in the muted state that Windows leaves behind and macOS's AppleHDA init never clears. Comparing a broken vs. a working codec dump, coef 0x10 reads `0x0220` (bit 9 / mute set) when broken and `0x0020` when working. Re-writing coef 0x10 to `0x0020` restores audio in every tested case. (Two further coefficients, 0x45 and 0x1A, also differ but were observed not to persist on read-back, so only the minimal, effective coef 0x10 write is shipped here.)

### Fix

A new layout 16, identical to Mirone's layout 3 except that the following two verbs are appended to both `ConfigData` (cold/warm boot) and `WakeConfigData` (sleep wake):

```
02 05 00 10   SET_COEF_INDEX  0x0010   on NID 0x20
02 04 00 20   SET_PROC_COEF   0x0020   on NID 0x20
```

`WakeVerbReinit` is `true` so the wake verbs are re-sent on every power transition.

Because the layout and platform data are byte-for-byte the same as Mirone layout 3, the new layout **reuses** `layout3.xml.zlib` and `PlatformsM.xml.zlib` rather than adding duplicate resource files (per the "avoid unnecessary duplication" rule on the Adding-codec-support wiki page).

### Files changed

- `Resources/ALC255/Info.plist` — new layout 16 entry in `Layouts` (→ `layout3.xml.zlib`) and `Platforms` (→ `PlatformsM.xml.zlib`).
- `Resources/PinConfigs.kext/Contents/Info.plist` — new `HDAConfigDefault` entry for CodecID 283902549 / LayoutID 16 with the patched `ConfigData` + `WakeConfigData`.
- `Changelog.md` — changelog line.

### Testing

Patched build on Gigabyte Aorus 15G, macOS Sequoia (24G624), OpenCore, `alcid=16`:

| Scenario                  | Stock layout 3 | New layout 16 |
| ------------------------- | :------------: | :-----------: |
| Cold boot                 |       ✅        |       ✅       |
| Warm reboot (Windows→mac) |       ❌        |       ✅       |
| Short sleep               |       ❌        |       ✅       |
| Medium sleep              |       ❌        |       ✅       |
| Long / deep sleep         |       ❌        |       ✅       |

(Audio settles ~8 s after boot/wake in all cases; that is codec settling time and is unrelated to the patch.)