### PR TITLE
ALCS1200A: add MAG B660M MORTAR WIFI DDR4 to layout-id 52

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 AppleALC Changelog
 ==================
+#### v1.9.8
+- Added ALCS1200A layout-id 52 for MAG B660M MORTAR WIFI DDR4 by Kinghammer1
+
 #### v1.9.7
 - Added ALC897 layout-id 31 for MSI X670E Gaming WIFI by yandong31
 - ALC892 changed MinKernel 13->12 by bugprogrammer

--- a/Resources/ALCS1200A/Info.plist
+++ b/Resources/ALCS1200A/Info.plist
@@ -86,7 +86,7 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>GeorgeWan - ALCS1200A for MSI-Mortar-B460M</string>
+				<string>GeorgeWan - ALCS1200A for MSI-Mortar-B460M (also MAG B660M MORTAR WIFI DDR4)</string>
 				<key>Id</key>
 				<integer>52</integer>
 				<key>Path</key>
@@ -193,7 +193,7 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>GeorgeWan - ALCS1200A for MSI-Mortar-B460M</string>
+				<string>GeorgeWan - ALCS1200A for MSI-Mortar-B460M (also MAG B660M MORTAR WIFI DDR4)</string>
 				<key>Id</key>
 				<integer>52</integer>
 				<key>Path</key>


### PR DESCRIPTION
Confirmed that layout-id 52 (originally for MSI-Mortar-B460M) also works on MAG B660M MORTAR WIFI DDR4 with identical ALCS1200A codec.